### PR TITLE
Rebuild landing layout with onboarding signup

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,16 @@ st.set_page_config(
 init_session_state()
 auth_service = AuthService()
 user = get_user()
+module_service = ModuleService()
+modules = [module.model_dump() for module in module_service.list_modules()]
+
+module_count = len(modules)
+average_minutes = (
+    int(sum(module["estimated_minutes"] for module in modules) / module_count)
+    if module_count
+    else 0
+)
+difficulty_levels = sorted({module["difficulty"] for module in modules}) if modules else []
 
 st.markdown(
     """
@@ -26,189 +36,455 @@ st.markdown(
         color-scheme: dark;
     }
     .stApp {
-        background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.18), transparent 55%),
-                    linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.85));
+        background: radial-gradient(circle at 15% 20%, rgba(56, 189, 248, 0.14), transparent 55%),
+                    radial-gradient(circle at 85% 10%, rgba(59, 130, 246, 0.12), transparent 45%),
+                    linear-gradient(160deg, rgba(12, 19, 35, 0.95), rgba(15, 23, 42, 0.9));
+        font-family: "Inter", "SF Pro Display", sans-serif;
     }
-    .hero {
-        padding: 3.5rem 3rem;
-        border-radius: 28px;
-        background: linear-gradient(135deg, rgba(56, 189, 248, 0.2), rgba(30, 64, 175, 0.4));
+    .page-shell {
+        padding: 2.5rem clamp(1.5rem, 5vw, 3.5rem) 4rem;
+        max-width: 1280px;
+        margin: 0 auto;
+    }
+    .top-nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding-bottom: 1.75rem;
+        gap: 1rem;
+    }
+    .brand {
+        font-size: 1.2rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        color: #e2e8f0;
+        text-transform: uppercase;
+    }
+    .nav-links {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+    .nav-links span {
+        padding: 0.45rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(148, 163, 184, 0.12);
         border: 1px solid rgba(148, 163, 184, 0.25);
-        position: relative;
-        overflow: hidden;
-        box-shadow: 0 30px 70px rgba(15, 23, 42, 0.55);
+        color: rgba(226, 232, 240, 0.9);
+        font-size: 0.85rem;
     }
-    .hero::after {
+    .landing-hero {
+        position: relative;
+        padding: clamp(2.4rem, 5vw, 3.5rem);
+        border-radius: 32px;
+        background: linear-gradient(145deg, rgba(14, 116, 144, 0.38), rgba(15, 118, 110, 0.18));
+        border: 1px solid rgba(94, 234, 212, 0.18);
+        box-shadow: 0 30px 80px rgba(14, 165, 233, 0.18);
+        display: grid;
+        gap: clamp(2rem, 4vw, 3.5rem);
+        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    }
+    .landing-hero::after {
         content: "";
         position: absolute;
         inset: 0;
-        background: radial-gradient(circle at top right, rgba(125, 211, 252, 0.4), transparent 45%);
-        opacity: 0.6;
+        border-radius: inherit;
+        background: radial-gradient(circle at 30% 20%, rgba(125, 211, 252, 0.35), transparent 50%);
         pointer-events: none;
+        opacity: 0.6;
     }
-    .hero h1 {
-        font-size: 3.2rem;
-        margin-bottom: 1rem;
-        color: #e0f2fe;
+    .hero-copy {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 1.3rem;
+        color: rgba(226, 232, 240, 0.95);
     }
-    .hero p {
+    .hero-pill {
+        align-self: flex-start;
+        padding: 0.5rem 1.15rem;
+        border-radius: 999px;
+        background: rgba(20, 184, 166, 0.22);
+        color: #99f6e4;
+        font-size: 0.85rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+    }
+    .hero-title {
+        margin: 0;
+        font-size: clamp(2.6rem, 5vw, 3.8rem);
+        color: #ecfeff;
+    }
+    .hero-body {
+        margin: 0;
+        font-size: 1.1rem;
         max-width: 640px;
-        font-size: 1.15rem;
+        line-height: 1.6;
         color: rgba(226, 232, 240, 0.9);
     }
-    .feature-grid {
+    .hero-highlights {
+        margin: 0;
+        padding-left: 0;
+        list-style: none;
+        display: grid;
+        gap: 0.75rem;
+    }
+    .hero-highlights li {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.65rem;
+    }
+    .hero-highlights li::before {
+        content: "✦";
+        color: #a5f3fc;
+        margin-top: 0.1rem;
+    }
+    .hero-actions {
+        margin-top: 0.75rem;
+    }
+    .hero-actions .stButton>button {
+        border-radius: 16px;
+        padding: 0.9rem 1.4rem;
+        font-weight: 600;
+        border: 1px solid rgba(56, 189, 248, 0.45);
+        background: rgba(12, 74, 110, 0.55);
+        color: #e0f2fe;
+        transition: transform 0.2s ease, background 0.2s ease;
+    }
+    .hero-actions .stButton>button:hover {
+        transform: translateY(-2px);
+        background: rgba(56, 189, 248, 0.35);
+    }
+    .hero-panel {
+        position: relative;
+        z-index: 1;
+        background: rgba(15, 23, 42, 0.92);
+        border-radius: 28px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        padding: 1.8rem 1.6rem;
+        box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.1);
+    }
+    .hero-panel .stTabs {
+        margin-top: 1rem;
+    }
+    .data-strip {
+        margin-top: 2.5rem;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1rem;
+    }
+    .data-stat {
+        padding: 1.25rem 1.35rem;
+        border-radius: 22px;
+        background: rgba(15, 23, 42, 0.82);
+        border: 1px solid rgba(94, 234, 212, 0.2);
+    }
+    .data-stat strong {
+        display: block;
+        font-size: 1.8rem;
+        color: #ecfeff;
+    }
+    .data-stat span {
+        color: rgba(148, 163, 184, 0.85);
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+    }
+    .spotlights {
+        margin-top: 1.5rem;
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-        gap: 1.5rem;
-        margin-top: 2rem;
+        gap: 1.25rem;
     }
-    .feature-card {
-        padding: 1.5rem;
+    .spotlight-card {
+        padding: 1.6rem;
         border-radius: 20px;
-        background: rgba(15, 23, 42, 0.75);
+        background: rgba(15, 23, 42, 0.85);
         border: 1px solid rgba(56, 189, 248, 0.2);
-        backdrop-filter: blur(12px);
+        color: rgba(226, 232, 240, 0.9);
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        min-height: 180px;
     }
-    .feature-card h3 {
+    .spotlight-card h3 {
+        margin: 0;
         color: #bae6fd;
+        font-size: 1.1rem;
     }
-    .pill {
-        display: inline-flex;
+    .curriculum-filter {
+        margin: 2.75rem 0 1.25rem;
+        display: flex;
+        flex-wrap: wrap;
         align-items: center;
-        gap: 0.4rem;
-        padding: 0.5rem 1rem;
-        border-radius: 999px;
-        background: rgba(14, 165, 233, 0.18);
-        color: #bae6fd;
-        font-size: 0.9rem;
-        margin-bottom: 1.5rem;
+        justify-content: space-between;
+        gap: 1rem;
     }
-    .cta-button {
+    .curriculum-filter span {
+        color: rgba(226, 232, 240, 0.85);
+        font-size: 0.95rem;
+    }
+    .module-board {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 1.35rem;
         width: 100%;
-        border-radius: 18px !important;
-        padding: 0.85rem 1.5rem !important;
-        font-weight: 600;
     }
     .module-card {
-        padding: 1.25rem 1.5rem;
-        border-radius: 20px;
-        background: rgba(15, 23, 42, 0.65);
-        border: 1px solid rgba(148, 163, 184, 0.18);
+        padding: 1.6rem;
+        border-radius: 22px;
+        background: rgba(15, 23, 42, 0.82);
+        border: 1px solid rgba(148, 163, 184, 0.22);
+        display: flex;
+        flex-direction: column;
+        gap: 0.9rem;
+        min-height: 220px;
+    }
+    .module-card h4 {
+        margin: 0;
+        color: #f8fafc;
+        font-size: 1.15rem;
+    }
+    .module-meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.9rem;
+        color: rgba(148, 163, 184, 0.85);
+    }
+    .badge {
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        background: rgba(59, 130, 246, 0.18);
+        border: 1px solid rgba(59, 130, 246, 0.35);
+        color: #bfdbfe;
+        font-size: 0.8rem;
+    }
+    .goal-chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.35rem 0.7rem;
+        border-radius: 999px;
+        background: rgba(45, 212, 191, 0.18);
+        color: #99f6e4;
+        border: 1px solid rgba(94, 234, 212, 0.28);
+        font-size: 0.78rem;
+        margin: 0.2rem 0.25rem 0 0;
+    }
+    .recommendation-panel {
+        margin-top: 1.5rem;
+        padding: 1.75rem 1.5rem;
+        border-radius: 24px;
+        background: rgba(15, 23, 42, 0.9);
+        border: 1px solid rgba(56, 189, 248, 0.2);
+    }
+    .footer-note {
+        margin-top: 3rem;
+        color: rgba(148, 163, 184, 0.75);
+        text-align: center;
+        font-size: 0.9rem;
+    }
+    @media (max-width: 1100px) {
+        .landing-hero {
+            grid-template-columns: 1fr;
+        }
+        .hero-actions .stButton>button {
+            width: 100%;
+        }
     }
     </style>
     """,
     unsafe_allow_html=True,
 )
 
-with st.container():
-    st.markdown("<div class='hero'>", unsafe_allow_html=True)
-    st.markdown("<div class='pill'>🚀 Level up your Python skills</div>", unsafe_allow_html=True)
-    st.markdown("<h1>PyMasters</h1>", unsafe_allow_html=True)
-    st.markdown(
-        """<p>Interactive Python mastery crafted for developers who crave progress. Real-time code execution, curated learning paths, and analytics-driven recommendations—all powered by Streamlit.</p>""",
-        unsafe_allow_html=True,
-    )
+st.markdown("<div class='page-shell'>", unsafe_allow_html=True)
 
-    cta_col, auth_col = st.columns([3, 2], gap="large")
-
-    with cta_col:
-        st.markdown("### What will you build today?")
-        st.write(
-            "Design a personalised learning sprint, pair practice sessions with code challenges, "
-            "and turn insights into momentum with our progress analytics dashboard."
-        )
-        for label, helper in [
-            ("🧪 Run a code experiment", "Launch the sandbox"),
-            ("🧭 Explore learning paths", "Browse modules"),
-            ("📈 Review progress", "Open analytics"),
-        ]:
-            if st.button(label, key=helper, use_container_width=True):
-                st.experimental_set_query_params(action=helper)
-    with auth_col:
-        if user:
-            st.success(f"Welcome back, {user['name']}! Explore the dashboard or pick a new challenge.")
-        else:
-            render_login(auth_service)
-
-    st.markdown("</div>", unsafe_allow_html=True)
-
-st.markdown("---")
-
-module_service = ModuleService()
-modules = [module.dict() for module in module_service.list_modules()]
-
-module_count = len(modules)
-average_minutes = int(sum(module["estimated_minutes"] for module in modules) / module_count)
-difficulty_levels = sorted({module["difficulty"] for module in modules})
-
-metric_col1, metric_col2, metric_col3 = st.columns(3)
-metric_col1.metric("Active learning paths", f"{module_count}")
-metric_col2.metric("Avg. completion time", f"{average_minutes} min")
-metric_col3.metric("Daily exercises", "25+ curated")
-
-st.markdown("## Platform highlights")
 st.markdown(
     """
-    <div class='feature-grid'>
-      <div class='feature-card'>
-        <h3>Personalized Journeys</h3>
-        <p>Adaptive module sequencing based on your performance and goals.</p>
-      </div>
-      <div class='feature-card'>
-        <h3>Secure Sandbox</h3>
-        <p>Execute Python snippets with instant feedback powered by a dedicated sandbox microservice.</p>
-      </div>
-      <div class='feature-card'>
-        <h3>Progress Intelligence</h3>
-        <p>Track learning streaks, analytics, and export reports for your portfolio.</p>
-      </div>
-      <div class='feature-card'>
-        <h3>Community Challenges</h3>
-        <p>Daily coding quests and leaderboards keep you motivated and accountable.</p>
-      </div>
-    </div>
+    <header class='top-nav'>
+        <div class='brand'>PyMasters</div>
+        <div class='nav-links'>
+            <span>Curriculum</span>
+            <span>Progress</span>
+            <span>Community</span>
+        </div>
+    </header>
     """,
     unsafe_allow_html=True,
 )
 
-st.markdown("---")
-st.subheader("Learning paths tailored to your momentum")
+with st.container():
+    st.markdown("<section class='landing-hero'>", unsafe_allow_html=True)
+    hero_left, hero_right = st.columns((7, 5), gap="large")
 
-tabs = st.tabs([f"{difficulty.title()}" for difficulty in difficulty_levels])
-for tab, difficulty in zip(tabs, difficulty_levels):
-    with tab:
-        filtered_modules = [module for module in modules if module["difficulty"] == difficulty]
+    with hero_left:
+        st.markdown(
+            """
+            <div class='hero-copy'>
+                <div class='hero-pill'>New · Adaptive Python studio</div>
+                <h1 class='hero-title'>Design your next Python breakthrough</h1>
+                <p class='hero-body'>Orchestrate projects, coaching, and code reviews from a single adaptive workspace. PyMasters evolves with your goals, whether you're building automations, APIs, or AI-driven tooling.</p>
+                <ul class='hero-highlights'>
+                    <li>Blueprints that translate theory into shipping-ready artifacts.</li>
+                    <li>Guided retros and analytics that keep teams aligned.</li>
+                    <li>Community labs designed for pair programming and mentorship.</li>
+                </ul>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        st.markdown("<div class='hero-actions'>", unsafe_allow_html=True)
+        primary_cta, secondary_cta = st.columns(2, gap="medium")
+        with primary_cta:
+            if st.button("Start guided tour", key="cta_tour", use_container_width=True):
+                st.experimental_set_query_params(section="tour")
+        with secondary_cta:
+            if st.button("Browse curriculum", key="cta_curriculum", use_container_width=True):
+                st.experimental_set_query_params(section="curriculum")
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    with hero_right:
+        st.markdown("<div class='hero-panel'>", unsafe_allow_html=True)
+        if user:
+            st.success(
+                f"Welcome back, {user['name']}! Continue your streak or launch a new sprint.",
+                icon="✨",
+            )
+            st.metric("Active journeys", f"{module_count}")
+            st.metric("Average sprint", f"{average_minutes} min" if average_minutes else "n/a")
+        else:
+            render_login(auth_service)
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    st.markdown("</section>", unsafe_allow_html=True)
+
+stats_html = f"""
+<section class='data-strip'>
+    <div class='data-stat'>
+        <span>Learning paths</span>
+        <strong>{module_count}</strong>
+        <p>Modular sprints curated by senior mentors.</p>
+    </div>
+    <div class='data-stat'>
+        <span>Avg. completion</span>
+        <strong>{average_minutes if average_minutes else '––'} min</strong>
+        <p>Time to ship a focused module.</p>
+    </div>
+    <div class='data-stat'>
+        <span>Live sessions</span>
+        <strong>3 / week</strong>
+        <p>Workshops, office hours, and code clinics.</p>
+    </div>
+</section>
+"""
+st.markdown(stats_html, unsafe_allow_html=True)
+
+st.markdown("### Why teams choose PyMasters")
+st.caption("A modern delivery pipeline for Python learning, complete with analytics, coaching, and production-grade tooling.")
+
+spotlights = [
+    (
+        "Adaptive workspaces",
+        "Spin up focused sandboxes with preloaded datasets, tests, and scaffolding tailored to each learning path.",
+    ),
+    (
+        "Delivery cadences",
+        "Weekly checkpoints, async retros, and pair-programming prompts keep momentum visible and measurable.",
+    ),
+    (
+        "Insightful analytics",
+        "Understand how code quality, velocity, and retention trend over time with exportable dashboards.",
+    ),
+    (
+        "Community accelerators",
+        "Access curated guilds, lightning talks, and challenge ladders that expand your network while you learn.",
+    ),
+]
+
+spotlight_html = "<div class='spotlights'>"
+for title, description in spotlights:
+    spotlight_html += (
+        "<div class='spotlight-card'>"
+        f"<h3>{title}</h3>"
+        f"<p>{description}</p>"
+        "</div>"
+    )
+spotlight_html += "</div>"
+st.markdown(spotlight_html, unsafe_allow_html=True)
+
+st.markdown("### Choose your next build cycle")
+st.caption("Filter by focus level to see where you and your team should invest the next sprint.")
+
+if not modules:
+    st.info("Modules are loading. Refresh the page to explore learning paths.")
+else:
+    difficulty_options = ["All levels"] + [difficulty.title() for difficulty in difficulty_levels]
+    selected_difficulty = st.radio(
+        "Select difficulty",
+        difficulty_options,
+        horizontal=True,
+        label_visibility="collapsed",
+        index=0,
+        key="difficulty-filter",
+    )
+
+    if selected_difficulty == "All levels":
+        filtered_modules = modules
+    else:
+        normalized = selected_difficulty.lower()
+        filtered_modules = [
+            module for module in modules if module["difficulty"].lower() == normalized
+        ]
+
+    if not filtered_modules:
+        st.info("No modules match that focus just yet. Check back soon!")
+    else:
+        module_summary = (
+            "<div class='curriculum-filter'><span>"
+            f"{len(filtered_modules)} modules ready with real briefs and starter repos."
+            "</span></div>"
+        )
+        st.markdown(module_summary, unsafe_allow_html=True)
+        module_html = "<div class='module-board'>"
         for module in filtered_modules:
-            with st.container():
-                st.markdown("<div class='module-card'>", unsafe_allow_html=True)
-                st.markdown(f"#### {module['title']}")
-                st.write(module["description"])
-                chip_str = " ".join(f"`{tag}`" for tag in module["tags"])
-                st.caption(f"Difficulty: {module['difficulty']} · {module['estimated_minutes']} minutes")
-                if chip_str:
-                    st.caption(chip_str)
-                st.markdown("</div>", unsafe_allow_html=True)
-            st.divider()
+            tag_html = "".join(f"<span class='goal-chip'>{tag}</span>" for tag in module["tags"])
+            module_html += (
+                "<div class='module-card'>"
+                f"<h4>{module['title']}</h4>"
+                f"<p>{module['description']}</p>"
+                f"<div class='module-meta'><span>{module['difficulty'].title()} track</span>"
+                f"<span class='badge'>{module['estimated_minutes']} min</span></div>"
+                f"<div>{tag_html}</div>"
+                "</div>"
+            )
+        module_html += "</div>"
+        st.markdown(module_html, unsafe_allow_html=True)
 
 if user:
-    st.markdown("---")
-    st.subheader("Recommended for you")
+    st.markdown("### Personalized focus board")
+    st.caption("Based on your completions, here are the next challenges to keep the streak alive.")
     progress_service = ProgressService()
     recommendation_service = RecommendationService()
-    progress_records = [record.dict() for record in progress_service.list_progress(user["id"])]
+    progress_records = [record.model_dump() for record in progress_service.list_progress(user["id"])]
     completed_module_ids = [record["module_id"] for record in progress_records]
     recommendations = recommendation_service.get_recommendations(
         user_id=user["id"], completed_module_ids=completed_module_ids
     )
+    st.markdown("<div class='recommendation-panel'>", unsafe_allow_html=True)
     render_recommendation_carousel(recommendations)
+    st.markdown("</div>", unsafe_allow_html=True)
 else:
-    st.info("Sign in to unlock personalized recommendations and progress tracking.")
+    st.info("Sign in or create an account to unlock personalised recommendations and progress tracking.")
 
-st.markdown("---")
-st.caption(
+st.markdown(
     """
-    PyMasters is designed for custom deployments. Configure environment variables via `.env` and connect
-    PostgreSQL, Redis, and background workers to enable production-grade workflows.
-    """
+    <div class='footer-note'>
+        PyMasters is deploy-ready for custom environments. Configure secrets, databases, and workers to power richer workflows.<br/>
+        Environment: <strong>{env}</strong>
+    </div>
+    """.format(env=settings.environment.capitalize()),
+    unsafe_allow_html=True,
 )
-st.caption(f"Environment: {settings.environment.capitalize()}")
+
+st.markdown("</div>", unsafe_allow_html=True)

--- a/config/settings.py
+++ b/config/settings.py
@@ -35,11 +35,22 @@ class Settings(BaseSettings):
             "community_features": False,
         }
     )
+    mongodb_uri: Optional[str] = Field(
+        default=None,
+        env="mongodb_uri",
+        description="Optional MongoDB connection string for auxiliary services.",
+    )
+    mongodb_db: Optional[str] = Field(
+        default=None,
+        env="mongodb_db",
+        description="Optional MongoDB database name for auxiliary services.",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
+        extra="ignore",
     )
 
 

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -20,8 +20,9 @@ class AuthService:
         return data
 
     def authenticate(self, email: str, password: str) -> Optional[User]:
+        normalized_email = email.strip().lower()
         for user in self._users:
-            if user.email.lower() == email.lower() and user.password == password:
+            if user.email.lower() == normalized_email and user.password == password:
                 return user
         return None
 
@@ -33,3 +34,36 @@ class AuthService:
 
     def list_users(self) -> list[User]:
         return list(self._users)
+
+    def create_user(
+        self,
+        *,
+        name: str,
+        email: str,
+        password: str,
+        skill_level: str,
+        learning_goals: list[str] | None = None,
+        avatar_url: str | None = None,
+    ) -> User:
+        """Create a new in-memory user for demo purposes."""
+
+        normalized_email = email.strip().lower()
+        if not normalized_email:
+            raise ValueError("Email is required.")
+
+        if any(user.email.lower() == normalized_email for user in self._users):
+            raise ValueError("That email is already registered. Try signing in instead.")
+
+        next_id = max((user.id for user in self._users), default=0) + 1
+        cleaned_name = name.strip() or normalized_email.split("@")[0].title()
+        user = User(
+            id=next_id,
+            email=normalized_email,
+            name=cleaned_name,
+            password=password,
+            skill_level=skill_level,
+            learning_goals=learning_goals or [],
+            avatar_url=avatar_url,
+        )
+        self._users.append(user)
+        return user

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -8,23 +8,69 @@ from utils.state import get_user, set_user
 
 
 def render_login(auth_service: AuthService) -> None:
-    """Render login/signup forms."""
+    """Render login and signup forms side-by-side."""
 
-    st.subheader("Sign in to continue")
-    with st.form("login-form", clear_on_submit=False):
-        email = st.text_input("Email", placeholder="you@pymasters.net")
-        password = st.text_input("Password", type="password")
-        submit = st.form_submit_button("Sign in")
+    st.subheader("Access your workspace")
+    login_tab, signup_tab = st.tabs(["Sign in", "Create account"])
 
-    if submit:
-        user = auth_service.authenticate(email=email, password=password)
-        if not user:
-            st.error("Invalid credentials. Try `pymasters` as the password for demo accounts.")
-        else:
-            set_user(user.dict())
-            st.experimental_rerun()
+    with login_tab:
+        with st.form("login-form", clear_on_submit=False):
+            email = st.text_input("Email", placeholder="you@pymasters.net")
+            password = st.text_input("Password", type="password")
+            submit = st.form_submit_button("Sign in")
 
-    st.caption("Don't have an account yet? Reach out to our team for beta access.")
+        if submit:
+            user = auth_service.authenticate(email=email, password=password)
+            if not user:
+                st.error(
+                    "Invalid credentials. Try `pymasters` as the password for demo accounts."
+                )
+            else:
+                set_user(user.model_dump())
+                st.experimental_rerun()
+
+    with signup_tab:
+        with st.form("signup-form", clear_on_submit=False):
+            name = st.text_input("Full name", placeholder="Ada Lovelace")
+            email = st.text_input("Email address", placeholder="you@pymasters.net")
+            password = st.text_input("Password", type="password")
+            skill_level = st.selectbox(
+                "Skill level",
+                ("Beginner", "Intermediate", "Advanced"),
+                index=1,
+            )
+            learning_goals = st.multiselect(
+                "Focus areas",
+                [
+                    "Automation",
+                    "Data pipelines",
+                    "APIs",
+                    "AI assistants",
+                    "Testing",
+                ],
+            )
+            submit_signup = st.form_submit_button("Create my account")
+
+        if submit_signup:
+            if not password:
+                st.error("Please choose a password to secure your account.")
+            else:
+                try:
+                    user = auth_service.create_user(
+                        name=name,
+                        email=email,
+                        password=password,
+                        skill_level=skill_level,
+                        learning_goals=learning_goals,
+                    )
+                except ValueError as error:
+                    st.error(str(error))
+                else:
+                    set_user(user.model_dump())
+                    st.success("Account created! You're now signed in.")
+                    st.experimental_rerun()
+
+    st.caption("Test accounts use `pymasters` as the password. Create your own to explore.")
 
 
 def ensure_authenticated(auth_service: AuthService) -> dict:


### PR DESCRIPTION
## Summary
- rebuild the homepage layout with new navigation, hero, spotlight, and curriculum preview sections
- add a tabbed sign-in/sign-up experience so visitors can create demo accounts inline
- extend the auth service with create_user support and email normalization for new signups

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691499e204648328a91522c7f11e303e)