### PR TITLE
Add Streamlit rerun helper for compatibility

### DIFF
--- a/pymasters_app/main.py
+++ b/pymasters_app/main.py
@@ -8,6 +8,7 @@ from pymasters_app.components.sidebar import render_sidebar
 from pymasters_app.pages import dashboard, login, profile, signup
 from pymasters_app.utils.auth import AuthManager
 from pymasters_app.utils.db import get_database
+from utils.streamlit_helpers import rerun
 
 st.set_page_config(
     page_title="PyMasters · Learn Python the modern way",
@@ -63,7 +64,7 @@ if selected_page != st.session_state["current_page"]:
 if st.session_state["current_page"] == "Log out":
     auth_manager.logout()
     st.session_state["current_page"] = "Login"
-    st.experimental_rerun()
+    rerun()
 
 user = auth_manager.get_current_user()
 render_header(user=user, on_logout=auth_manager.logout)

--- a/pymasters_app/pages/dashboard.py
+++ b/pymasters_app/pages/dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import streamlit as st
 
 from pymasters_app.utils import helpers
+from utils.streamlit_helpers import rerun
 
 
 STATUS_LABELS = {
@@ -60,15 +61,15 @@ def render(*, db, user: dict[str, str]) -> None:
         if action_cols[0].button("Start", key=f"start-{module['id']}"):
             helpers.upsert_progress(progress_collection, user_id=user["id"], module_id=module["id"], status="in_progress")
             st.toast(f"Marked {module['title']} as in progress.")
-            st.experimental_rerun()
+            rerun()
         if action_cols[1].button("Completed", key=f"complete-{module['id']}"):
             helpers.upsert_progress(progress_collection, user_id=user["id"], module_id=module["id"], status="completed")
             st.toast(f"Marked {module['title']} as completed. 🎉")
-            st.experimental_rerun()
+            rerun()
         if action_cols[2].button("Reset", key=f"reset-{module['id']}"):
             helpers.upsert_progress(progress_collection, user_id=user["id"], module_id=module["id"], status="not_started")
             st.toast(f"Reset progress for {module['title']}")
-            st.experimental_rerun()
+            rerun()
 
         st.divider()
 

--- a/pymasters_app/pages/login.py
+++ b/pymasters_app/pages/login.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import streamlit as st
 
 from pymasters_app.utils.auth import AuthManager
+from utils.streamlit_helpers import rerun
 
 
 def render(auth_manager: AuthManager) -> None:
@@ -28,7 +29,7 @@ def render(auth_manager: AuthManager) -> None:
 
         st.success(f"Welcome back, {user['name']}! Redirecting to your dashboard...")
         st.session_state["current_page"] = "Dashboard"
-        st.experimental_rerun()
+        rerun()
 
     st.divider()
     st.info("New to PyMasters? Jump over to the **Sign Up** page to create your free account.")

--- a/pymasters_app/pages/profile.py
+++ b/pymasters_app/pages/profile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import streamlit as st
 
 from pymasters_app.utils.auth import AuthManager
+from utils.streamlit_helpers import rerun
 
 
 def render(*, auth_manager: AuthManager, user: dict[str, str]) -> None:
@@ -24,7 +25,7 @@ def render(*, auth_manager: AuthManager, user: dict[str, str]) -> None:
             st.success("Profile updated successfully.")
             if updated_user:
                 st.session_state["user"] = updated_user
-            st.experimental_rerun()
+            rerun()
 
     st.markdown("### Change password")
     with st.form("password-form", clear_on_submit=True):

--- a/pymasters_app/pages/signup.py
+++ b/pymasters_app/pages/signup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import streamlit as st
 
 from pymasters_app.utils.auth import AuthManager
+from utils.streamlit_helpers import rerun
 
 
 def render(auth_manager: AuthManager) -> None:
@@ -33,7 +34,7 @@ def render(auth_manager: AuthManager) -> None:
 
         st.success(f"Welcome aboard, {user['name']}! Redirecting you to the dashboard...")
         st.session_state["current_page"] = "Dashboard"
-        st.experimental_rerun()
+        rerun()
 
     st.divider()
     st.info("Already have an account? Head to the **Login** page to sign in.")

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -5,6 +5,7 @@ import streamlit as st
 
 from services.auth_service import AuthService
 from utils.state import get_user, set_user
+from utils.streamlit_helpers import rerun
 
 
 def render_login(auth_service: AuthService) -> None:
@@ -27,7 +28,7 @@ def render_login(auth_service: AuthService) -> None:
                 )
             else:
                 set_user(user.model_dump())
-                st.experimental_rerun()
+                rerun()
 
     with signup_tab:
         with st.form("signup-form", clear_on_submit=False):
@@ -68,7 +69,7 @@ def render_login(auth_service: AuthService) -> None:
                 else:
                     set_user(user.model_dump())
                     st.success("Account created! You're now signed in.")
-                    st.experimental_rerun()
+                    rerun()
 
     st.caption("Test accounts use `pymasters` as the password. Create your own to explore.")
 

--- a/utils/streamlit_helpers.py
+++ b/utils/streamlit_helpers.py
@@ -1,0 +1,19 @@
+"""Helpers for working with the Streamlit API."""
+from __future__ import annotations
+
+from typing import Callable
+
+import streamlit as st
+
+
+def rerun() -> None:
+    """Trigger a rerun using the available Streamlit API."""
+
+    rerun_callable: Callable[[], None] | None = getattr(st, "rerun", None)
+    if rerun_callable is None:
+        rerun_callable = getattr(st, "experimental_rerun", None)
+
+    if rerun_callable is None:
+        raise AttributeError("Streamlit rerun function is not available.")
+
+    rerun_callable()


### PR DESCRIPTION
## Summary
- add a utility that calls `st.rerun` when available and falls back to `st.experimental_rerun`
- update authentication and dashboard flows to use the helper so reruns work on newer Streamlit versions

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a78b2d708328bbd53059bafc133c)