### PR TITLE
feat: refresh landing experience and harden auth

### DIFF
--- a/pymasters_app/utils/bootstrap.py
+++ b/pymasters_app/utils/bootstrap.py
@@ -1,15 +1,17 @@
-"""Bootstrap utilities for MongoDB collections and indexes."""
+"""Bootstrap utilities for MongoDB (or local fallback) collections and indexes."""
 from __future__ import annotations
 
-from pymongo.database import Database
+from typing import Any
 
 
-def ensure_collections(db: Database) -> None:
+def ensure_collections(db: Any) -> None:
     """Create required collections and indexes if missing."""
     # Users
     if "users" not in db.list_collection_names():
         db.create_collection("users")
     db["users"].create_index("email", unique=True, sparse=True)
+    db["users"].create_index("username_normalized", unique=True)
+    db["users"].create_index("phone_normalized", unique=True, sparse=True)
 
     # Tutor sessions
     if "tutor_sessions" not in db.list_collection_names():

--- a/pymasters_app/utils/helpers.py
+++ b/pymasters_app/utils/helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+import json
 from pathlib import Path
 from typing import Any, Iterable
 

--- a/pymasters_app/utils/local_db.py
+++ b/pymasters_app/utils/local_db.py
@@ -1,0 +1,225 @@
+"""Minimal local JSON-backed database used when MongoDB is unavailable."""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Sequence
+from bson import ObjectId
+
+
+def _json_serializer(value: Any) -> Any:
+    """Serialize unsupported types (datetime/ObjectId) for JSON dumping."""
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, ObjectId):
+        return str(value)
+    raise TypeError(f"Type {type(value)!r} is not JSON serializable")
+
+
+class LocalCursor:
+    """Very small cursor abstraction that mimics pymongo's API surface."""
+
+    def __init__(self, documents: list[dict[str, Any]]):
+        self._documents = documents
+
+    def sort(self, key_or_list: Any, direction: int | None = None) -> "LocalCursor":
+        if isinstance(key_or_list, Sequence) and not isinstance(key_or_list, (str, bytes)):
+            pairs: list[tuple[Any, Any]] = []
+            for item in key_or_list:
+                if isinstance(item, (list, tuple)) and len(item) == 2:
+                    pairs.append((item[0], item[1]))
+                else:
+                    pairs.append((item, 1))
+        else:
+            pairs = [(key_or_list, direction or 1)]
+
+        for field, direction in reversed(pairs):
+            reverse = direction in (-1, "desc", "descending")
+            self._documents.sort(key=lambda doc, field=field: doc.get(field), reverse=reverse)
+        return self
+
+    def limit(self, value: int) -> "LocalCursor":
+        if value >= 0:
+            self._documents = self._documents[: value]
+        return self
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        return iter(self._documents)
+
+
+class LocalJSONCollection:
+    """Lightweight collection persisting documents to disk as JSON."""
+
+    def __init__(self, name: str, base_dir: Path):
+        self._name = name
+        self._path = base_dir / f"{name}.json"
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._documents: list[dict[str, Any]] = []
+        self._load()
+
+    # Mongo compatibility -------------------------------------------------
+    def create_index(self, *_: Any, **__: Any) -> None:  # pragma: no cover - compatibility no-op
+        return None
+
+    def estimated_document_count(self) -> int:
+        return len(self._documents)
+
+    def find_one(self, query: dict[str, Any] | None = None) -> dict[str, Any] | None:
+        query = query or {}
+        for document in self._documents:
+            if self._matches(document, query):
+                return deepcopy(document)
+        return None
+
+    def find(self, query: dict[str, Any] | None = None, projection: dict[str, Any] | None = None) -> LocalCursor:
+        query = query or {}
+        projection = projection or {}
+        rows: list[dict[str, Any]] = []
+        for document in self._documents:
+            if self._matches(document, query):
+                payload = deepcopy(document)
+                if projection:
+                    payload = {k: payload.get(k) for k in projection if projection[k]}
+                    if "_id" not in payload:
+                        payload["_id"] = document.get("_id")
+                rows.append(payload)
+        return LocalCursor(rows)
+
+    def insert_one(self, document: dict[str, Any]):
+        payload = deepcopy(document)
+        payload.setdefault("_id", str(ObjectId()))
+        payload["_id"] = str(payload["_id"])
+        self._documents.append(payload)
+        self._persist()
+
+        class Result:
+            inserted_id = payload["_id"]
+
+        return Result()
+
+    def insert_many(self, documents: Iterable[dict[str, Any]]):
+        inserted_ids: list[str] = []
+        for document in documents:
+            result = self.insert_one(document)
+            inserted_ids.append(result.inserted_id)
+
+        class Result:
+            inserted_ids = inserted_ids
+
+        return Result()
+
+    def update_one(self, query: dict[str, Any], update: dict[str, Any], upsert: bool = False):
+        index = self._find_index(query)
+        if index is not None:
+            document = self._documents[index]
+            if "$set" in update:
+                document.update(update["$set"])
+            if "$setOnInsert" in update:
+                for key, value in update["$setOnInsert"].items():
+                    document.setdefault(key, value)
+            self._documents[index] = document
+            self._persist()
+
+            class Result:
+                matched_count = 1
+                modified_count = 1
+                upserted_id = None
+
+            return Result()
+
+        if not upsert:
+            class Result:
+                matched_count = 0
+                modified_count = 0
+                upserted_id = None
+
+            return Result()
+
+        new_document: dict[str, Any] = {}
+        for key, value in (query or {}).items():
+            if isinstance(value, dict) and "$ne" in value:
+                continue
+            new_document[key] = value
+        if "$setOnInsert" in update:
+            new_document.update(update["$setOnInsert"])
+        if "$set" in update:
+            new_document.update(update["$set"])
+        result = self.insert_one(new_document)
+
+        class UpsertResult:
+            matched_count = 0
+            modified_count = 0
+            upserted_id = result.inserted_id
+
+        return UpsertResult()
+
+    def delete_one(self, query: dict[str, Any]):
+        index = self._find_index(query)
+        if index is not None:
+            self._documents.pop(index)
+            self._persist()
+
+    # Helpers -------------------------------------------------------------
+    def _find_index(self, query: dict[str, Any]) -> int | None:
+        for idx, document in enumerate(self._documents):
+            if self._matches(document, query):
+                return idx
+        return None
+
+    def _matches(self, document: dict[str, Any], query: dict[str, Any]) -> bool:
+        for key, expected in query.items():
+            actual = document.get(key)
+            if isinstance(actual, ObjectId):
+                actual = str(actual)
+            if isinstance(expected, dict) and "$ne" in expected:
+                if str(actual) == str(expected["$ne"]):
+                    return False
+                continue
+            if isinstance(expected, ObjectId):
+                expected = str(expected)
+            if actual != expected:
+                return False
+        return True
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            self._documents = []
+            return
+        try:
+            self._documents = json.loads(self._path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            self._documents = []
+
+    def _persist(self) -> None:
+        self._path.write_text(json.dumps(self._documents, default=_json_serializer, indent=2), encoding="utf-8")
+
+
+class LocalJSONDatabase:
+    """Container object mimicking pymongo.database.Database."""
+
+    is_local = True
+
+    def __init__(self, name: str, root: Path | None = None):
+        self._name = name
+        self._root = (root or Path(".pymasters_localdb")) / name
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._collections: dict[str, LocalJSONCollection] = {}
+
+    def __getitem__(self, name: str) -> LocalJSONCollection:
+        if name not in self._collections:
+            self._collections[name] = LocalJSONCollection(name, self._root)
+        return self._collections[name]
+
+    def list_collection_names(self) -> list[str]:
+        disk_names = [path.stem for path in self._root.glob("*.json")]
+        mem_names = list(self._collections.keys())
+        return sorted(set(disk_names + mem_names))
+
+    def create_collection(self, name: str) -> LocalJSONCollection:
+        collection = self[name]
+        collection._persist()
+        return collection
+

--- a/pymasters_app/views/dashboard.py
+++ b/pymasters_app/views/dashboard.py
@@ -1,4 +1,3 @@
-﻿"""Dashboard page for authenticated users."""
 from __future__ import annotations
 
 import streamlit as st
@@ -8,14 +7,15 @@ from utils.streamlit_helpers import rerun
 
 
 STATUS_LABELS = {
-    "not_started": ("Not started", "#cbd5f5"),
-    "in_progress": ("In progress", "#facc15"),
-    "completed": ("Completed", "#22c55e"),
+    "not_started": ("Queued", "not_started"),
+    "in_progress": ("In progress", "in_progress"),
+    "completed": ("Completed", "completed"),
 }
 
 
 def render(*, db, user: dict[str, str]) -> None:
-    """Render the dashboard view."""
+    """Render the dashboard view with immersive cards."""
+
     modules_collection = db["learning_modules"]
     progress_collection = db["progress"]
 
@@ -24,58 +24,184 @@ def render(*, db, user: dict[str, str]) -> None:
     progress_map = helpers.get_progress_by_user(progress_collection, user_id=user["id"])
     summary = helpers.summarize_progress(modules, progress_map)
 
-    st.write("## Dashboard")
-    st.caption("Review your progress and continue your personalised learning path.")
+    st.markdown(
+        """
+        <style>
+        .pm-dashboard-hero {
+            margin-top:0.5rem;
+            padding:2.4rem;
+            border-radius:32px;
+            border:1px solid rgba(56,189,248,0.35);
+            background:linear-gradient(135deg, rgba(15,23,42,0.9), rgba(2,6,23,0.85));
+            box-shadow:0 45px 140px -80px rgba(56,189,248,0.85);
+            display:flex;
+            align-items:flex-start;
+            justify-content:space-between;
+            gap:1.8rem;
+        }
+        .pm-dashboard-hero h2 {margin-bottom:0.4rem;}
+        .pm-dashboard-hero p {color:rgba(148,163,184,0.95);}
+        .pm-next-card {
+            margin-top:1rem;
+            padding:1.2rem 1.4rem;
+            border-radius:22px;
+            border:1px solid rgba(16,185,129,0.35);
+            background:rgba(6,78,59,0.45);
+        }
+        .pm-metric-grid {
+            margin:1.6rem 0 2rem;
+            display:grid;
+            grid-template-columns:repeat(auto-fit, minmax(210px, 1fr));
+            gap:1rem;
+        }
+        .pm-metric-card {
+            padding:1.2rem 1.4rem;
+            border-radius:22px;
+            border:1px solid rgba(148,163,184,0.25);
+            background:rgba(15,23,42,0.78);
+            box-shadow:0 30px 80px -60px rgba(15,118,110,0.8);
+        }
+        .pm-metric-card span {text-transform:uppercase; letter-spacing:0.25em; font-size:0.68rem; color:#bae6fd;}
+        .pm-metric-card strong {display:block; font-size:2rem; margin:0.4rem 0; color:#f8fafc;}
+        .pm-metric-card p {margin:0; color:rgba(148,163,184,0.95);}
+        .pm-module-card {
+            position:relative;
+            padding:1.6rem 1.8rem;
+            border-radius:26px;
+            border:1px solid rgba(148,163,184,0.25);
+            background:rgba(2,6,23,0.8);
+            margin-bottom:1rem;
+            box-shadow:0 40px 120px -70px rgba(14,165,233,0.65);
+        }
+        .pm-module-head {display:flex; justify-content:space-between; align-items:flex-start; gap:1rem;}
+        .pm-module-tags {display:flex; flex-wrap:wrap; gap:0.35rem; margin-top:0.65rem;}
+        .pm-tag {
+            padding:0.25rem 0.75rem;
+            border-radius:999px;
+            background:rgba(56,189,248,0.15);
+            color:#bae6fd;
+            font-size:0.82rem;
+            letter-spacing:0.05em;
+        }
+        .pm-status {
+            display:inline-flex;
+            align-items:center;
+            justify-content:center;
+            padding:0.35rem 0.85rem;
+            border-radius:999px;
+            text-transform:uppercase;
+            letter-spacing:0.24em;
+            font-size:0.68rem;
+        }
+        .pm-status-not_started {background:rgba(148,163,184,0.25); color:#cbd5f5;}
+        .pm-status-in_progress {background:rgba(250,204,21,0.2); color:#fde047;}
+        .pm-status-completed {background:rgba(34,197,94,0.2); color:#4ade80;}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
 
-    metrics = st.columns(3)
-    metrics[0].metric("Learning modules", summary["total_modules"])
-    metrics[1].metric("In progress", summary["in_progress"])
-    metrics[2].metric("Completed", summary["completed"])
+    next_focus = next(
+        (module for module in modules if progress_map.get(module["id"], {}).get("status") != "completed"),
+        modules[0] if modules else None,
+    )
+    next_title = next_focus["title"] if next_focus else "Explore the catalog"
+    next_meta = (
+        f"{next_focus['estimated_minutes']} min · {next_focus['difficulty'].title()}"
+        if next_focus
+        else "Browse missions"
+    )
+
+    st.markdown(
+        f"""
+        <div class="pm-dashboard-hero">
+            <div>
+                <p style="letter-spacing:0.35em; text-transform:uppercase; color:#a5f3fc;">Mission control</p>
+                <h2>Welcome back, {user.get('name') or user.get('username')}.</h2>
+                <p>Your personalised command cards surface progress velocity, ready-to-run modules, and studio drops.</p>
+            </div>
+            <div class="pm-next-card">
+                <strong>Next focus</strong>
+                <p style="margin:0.35rem 0 0.15rem; color:#f8fafc;">{next_title}</p>
+                <span style="font-size:0.85rem; color:#d1fae5;">{next_meta}</span>
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    st.markdown("<div class='pm-metric-grid'>", unsafe_allow_html=True)
+    for title, value, caption in [
+        ("Learning modules", summary["total_modules"], "curated for your path"),
+        ("In progress", summary["in_progress"], "actively running"),
+        ("Completed", summary["completed"], "mission victories"),
+    ]:
+        st.markdown(
+            f"""
+            <div class="pm-metric-card">
+                <span>{title}</span>
+                <strong>{value}</strong>
+                <p>{caption}</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+    st.markdown("</div>", unsafe_allow_html=True)
 
     st.markdown("### Continue your journey")
 
     for module in modules:
-        with st.container():
-            st.markdown(
-                f"""
-                <div style="background:rgba(15,23,42,0.55); padding:1.2rem 1.4rem; border-radius:18px; border:1px solid rgba(148,163,184,0.2); margin-bottom:0.75rem;">
-                    <div style="display:flex; justify-content:space-between; align-items:center;">
-                        <div>
-                            <h3 style="margin-bottom:0.4rem;">{module['title']}</h3>
-                            <p style="margin:0; color:#cbd5f5; max-width:720px;">{module['description']}</p>
-                            <div style="margin-top:0.6rem; display:flex; gap:0.4rem; flex-wrap:wrap;">
-                                {''.join(f'<span style=\"background:rgba(56,189,248,0.18); color:#bae6fd; padding:0.35rem 0.75rem; border-radius:999px; font-size:0.85rem;\">{tag}</span>' for tag in module.get('tags', []))}
-                            </div>
-                        </div>
-                        <div style="text-align:right;">
-                            <div style="color:#94a3b8; font-size:0.85rem;">{module['estimated_minutes']} min - {module['difficulty'].title()}</div>
-                            {render_status_chip(progress_map.get(module['id'], {'status': 'not_started'})['status'])}
+        status = progress_map.get(module["id"], {"status": "not_started"}).get("status", "not_started")
+        st.markdown(
+            f"""
+            <div class="pm-module-card">
+                <div class="pm-module-head">
+                    <div>
+                        <h3>{module['title']}</h3>
+                        <p style='margin:0; color:rgba(226,232,240,0.85);'>{module['description']}</p>
+                        <div class="pm-module-tags">
+                            {''.join(f"<span class='pm-tag'>{tag}</span>" for tag in module.get('tags', []))}
                         </div>
                     </div>
+                    <div style='text-align:right;'>
+                        <div style='font-size:0.85rem; color:rgba(148,163,184,0.9);'>{module['estimated_minutes']} min · {module['difficulty'].title()}</div>
+                        {render_status_chip(status)}
+                    </div>
                 </div>
-                """,
-                unsafe_allow_html=True,
-            )
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
 
         action_cols = st.columns(3)
         if action_cols[0].button("Start", key=f"start-{module['id']}"):
-            helpers.upsert_progress(progress_collection, user_id=user["id"], module_id=module["id"], status="in_progress")
+            helpers.upsert_progress(
+                progress_collection,
+                user_id=user["id"],
+                module_id=module["id"],
+                status="in_progress",
+            )
             st.toast(f"Marked {module['title']} as in progress.")
             rerun()
         if action_cols[1].button("Completed", key=f"complete-{module['id']}"):
-            helpers.upsert_progress(progress_collection, user_id=user["id"], module_id=module["id"], status="completed")
+            helpers.upsert_progress(
+                progress_collection,
+                user_id=user["id"],
+                module_id=module["id"],
+                status="completed",
+            )
             st.toast(f"Marked {module['title']} as completed.")
         if action_cols[2].button("Reset", key=f"reset-{module['id']}"):
-            helpers.upsert_progress(progress_collection, user_id=user["id"], module_id=module["id"], status="not_started")
+            helpers.upsert_progress(
+                progress_collection,
+                user_id=user["id"],
+                module_id=module["id"],
+                status="not_started",
+            )
             st.toast(f"Reset progress for {module['title']}")
             rerun()
 
-        st.divider()
-
 
 def render_status_chip(status: str) -> str:
-    label, color = STATUS_LABELS.get(status, STATUS_LABELS["not_started"])
-    return (
-        f"<span style='display:inline-block; margin-top:0.5rem; padding:0.3rem 0.75rem; background:{color}; color:#0f172a; border-radius:999px; font-weight:600; font-size:0.8rem;'>{label}</span>"
-    )
-
+    label, css = STATUS_LABELS.get(status, STATUS_LABELS["not_started"])
+    return f"<span class='pm-status pm-status-{css}'>{label}</span>"

--- a/pymasters_app/views/login.py
+++ b/pymasters_app/views/login.py
@@ -8,226 +8,208 @@ from utils.streamlit_helpers import rerun
 
 
 def render(auth_manager: AuthManager) -> None:
-    """Render the login view with a futuristic hero and glassmorphic form."""
+    """Render a cinematic landing page with a streamlined login form."""
 
     st.markdown(
         """
         <style>
-        .pm-hero-wrapper {
-            position:relative;
-            padding:1.2rem 0 2.8rem;
-        }
-        .pm-hero-section {
+        .pm-landing-grid {
             display:grid;
-            grid-template-columns:minmax(0, 1.05fr) minmax(0, 0.95fr);
-            gap:2.6rem;
-            align-items:center;
-        }
-        @media (max-width: 1180px) {
-            .pm-hero-section {grid-template-columns:1fr;}
-        }
-        .pm-hero-copy .eyebrow {
-            display:inline-flex;
-            align-items:center;
-            gap:0.35rem;
-            text-transform:uppercase;
-            letter-spacing:0.28em;
-            font-size:0.75rem;
-            color:#38bdf8;
-            background:rgba(8,47,73,0.58);
-            padding:0.35rem 0.85rem;
-            border-radius:999px;
-            border:1px solid rgba(56,189,248,0.35);
-            box-shadow:0 18px 40px -32px rgba(56,189,248,0.85);
-        }
-        .pm-hero-copy h1 {
-            font-size:3.2rem;
-            line-height:1.08;
+            grid-template-columns:minmax(0, 0.6fr) minmax(0, 0.4fr);
+            gap:2.5rem;
             margin-top:1.5rem;
-            margin-bottom:1rem;
         }
-        .pm-hero-copy h1 span {color:#38bdf8; text-shadow:0 0 28px rgba(56,189,248,0.45);}
-        .pm-hero-copy p {
-            max-width:520px;
-            font-size:1.05rem;
-            color:rgba(226,232,240,0.82);
+        @media (max-width: 1100px) {
+            .pm-landing-grid {grid-template-columns:1fr;}
         }
-        .pm-hero-actions {display:flex; align-items:center; gap:1.15rem; margin-top:1.6rem; flex-wrap:wrap;}
-        .pm-hero-actions .primary {
-            display:inline-flex;
-            align-items:center;
-            gap:0.65rem;
-            padding:0.65rem 1.6rem;
-            border-radius:999px;
-            text-transform:uppercase;
-            letter-spacing:0.32em;
-            font-weight:700;
-            font-size:0.75rem;
-            color:#020617;
-            background:linear-gradient(135deg, rgba(59,130,246,0.95), rgba(192,132,252,0.85));
-            text-decoration:none;
-            box-shadow:0 25px 65px -32px rgba(59,130,246,0.95);
-        }
-        .pm-hero-actions .ghost {
-            padding:0.55rem 1.4rem;
-            border-radius:999px;
-            border:1px solid rgba(148,163,184,0.3);
-            color:rgba(226,232,240,0.82);
-            letter-spacing:0.28em;
-            text-transform:uppercase;
-            font-size:0.72rem;
-            display:inline-flex;
-            align-items:center;
-            gap:0.45rem;
-            background:rgba(15,23,42,0.65);
-        }
-        .pm-hero-stats {
-            margin-top:2.1rem;
-            display:grid;
-            grid-template-columns:repeat(3, minmax(0, 1fr));
-            gap:1.1rem;
-            max-width:560px;
-        }
-        .pm-hero-stats .stat {
-            background:linear-gradient(160deg, rgba(8,47,73,0.8), rgba(15,23,42,0.7));
-            padding:0.9rem 1rem;
-            border-radius:18px;
-            border:1px solid rgba(56,189,248,0.25);
-            box-shadow:0 22px 55px -40px rgba(56,189,248,0.9);
-        }
-        .pm-hero-stats .stat strong {
-            display:block;
-            font-size:1.45rem;
-            color:#f8fafc;
-            font-family:'Orbitron', 'Inter', sans-serif;
-            letter-spacing:0.08em;
-        }
-        .pm-hero-stats .stat span {font-size:0.78rem; letter-spacing:0.2em; text-transform:uppercase; color:rgba(186,230,253,0.78);}
-        .pm-hero-visual {
-            position:relative;
-            display:flex;
-            align-items:center;
-            justify-content:center;
-        }
-        .pm-hero-visual .frame {
-            position:relative;
-            width:320px;
-            height:360px;
-            border-radius:30px;
-            background:linear-gradient(200deg, rgba(15,23,42,0.9), rgba(2,6,23,0.95));
+        .pm-landing-hero {
+            padding:2.5rem;
+            border-radius:36px;
+            background:linear-gradient(145deg, rgba(8,47,73,0.75), rgba(2,6,23,0.65));
             border:1px solid rgba(56,189,248,0.35);
+            box-shadow:0 55px 160px -80px rgba(56,189,248,0.85);
+            position:relative;
             overflow:hidden;
-            box-shadow:0 45px 95px -55px rgba(59,130,246,0.95);
         }
-        .pm-hero-visual .frame::before {
+        .pm-landing-hero::after {
             content:"";
             position:absolute;
             inset:0;
-            background:radial-gradient(circle at 50% 30%, rgba(56,189,248,0.35), transparent 60%);
-            opacity:0.85;
-        }
-        .pm-hero-visual .avatar {
-            position:absolute;
-            inset:12%;
-            background:radial-gradient(circle at 50% 20%, rgba(226,232,240,0.95), rgba(148,163,184,0.15));
-            mask:radial-gradient(circle at 50% 30%, rgba(0,0,0,0.02) 28%, rgba(0,0,0,0.55) 75%);
-            filter:saturate(1.25);
-            border-radius:26px;
-            box-shadow:inset 0 -40px 70px -35px rgba(56,189,248,0.75);
-        }
-        .pm-hero-visual .halo {
-            position:absolute;
-            width:92%;
-            height:92%;
-            border-radius:32px;
-            inset:4%;
-            border:1px dashed rgba(148,163,184,0.35);
-            animation:haloOrbit 9s linear infinite;
-        }
-        .pm-hero-visual .wave {
-            position:absolute;
-            bottom:-35px;
-            left:50%;
-            transform:translateX(-50%);
-            width:360px;
-            height:200px;
-            background:radial-gradient(ellipse at center, rgba(56,189,248,0.55), transparent 65%);
-            filter:blur(18px);
+            pointer-events:none;
+            background:radial-gradient(circle at 12% 20%, rgba(59,130,246,0.45), transparent 55%);
             opacity:0.6;
         }
-        .pm-hero-visual .scanner {
+        .pm-hero-badge {
+            display:inline-flex;
+            align-items:center;
+            gap:0.4rem;
+            padding:0.35rem 0.95rem;
+            border-radius:999px;
+            border:1px solid rgba(94,234,212,0.45);
+            background:rgba(15,118,110,0.18);
+            letter-spacing:0.28em;
+            text-transform:uppercase;
+            font-size:0.72rem;
+            color:#99f6e4;
+        }
+        .pm-landing-hero h1 {
+            font-size:3rem;
+            line-height:1.05;
+            margin:1.4rem 0 0.8rem;
+        }
+        .pm-landing-hero h1 span {
+            color:#38bdf8;
+            text-shadow:0 0 35px rgba(56,189,248,0.55);
+        }
+        .pm-hero-subcopy {
+            font-size:1.05rem;
+            color:rgba(241,245,249,0.85);
+            max-width:620px;
+        }
+        .pm-hero-cards {
+            display:grid;
+            grid-template-columns:repeat(auto-fit, minmax(180px, 1fr));
+            gap:1rem;
+            margin-top:2rem;
+        }
+        .pm-hero-card {
+            padding:1.1rem 1.3rem;
+            border-radius:22px;
+            border:1px solid rgba(148,163,184,0.25);
+            background:rgba(15,23,42,0.65);
+            box-shadow:0 25px 60px -40px rgba(8,145,178,0.65);
+        }
+        .pm-hero-card strong {
+            display:block;
+            font-size:1.6rem;
+            color:#f8fafc;
+            font-family:'Orbitron', 'Inter', sans-serif;
+        }
+        .pm-hero-card span {
+            display:block;
+            text-transform:uppercase;
+            letter-spacing:0.3em;
+            font-size:0.72rem;
+            color:rgba(148,163,184,0.85);
+            margin-top:0.35rem;
+        }
+        .pm-hero-cta {
+            margin-top:2.2rem;
+            display:flex;
+            flex-wrap:wrap;
+            gap:0.75rem;
+        }
+        .pm-hero-cta a {
+            padding:0.65rem 1.45rem;
+            border-radius:999px;
+            text-transform:uppercase;
+            letter-spacing:0.32em;
+            font-size:0.74rem;
+            font-weight:600;
+            border:1px solid rgba(148,163,184,0.35);
+            color:#e2e8f0;
+        }
+        .pm-hero-cta a.primary {
+            border:none;
+            color:#020617;
+            background:linear-gradient(120deg, rgba(56,189,248,0.95), rgba(192,132,252,0.85));
+            box-shadow:0 25px 65px -32px rgba(56,189,248,0.95);
+        }
+        .pm-auth-card {
+            position:relative;
+            padding:2.4rem;
+            border-radius:32px;
+            border:1px solid rgba(56,189,248,0.35);
+            background:linear-gradient(160deg, rgba(15,23,42,0.92), rgba(2,6,23,0.88));
+            box-shadow:0 45px 90px -60px rgba(8,145,178,0.8);
+        }
+        .pm-auth-card::after {
+            content:"";
             position:absolute;
-            left:15%;
-            top:20%;
-            width:70%;
-            height:2px;
-            background:linear-gradient(90deg, transparent, rgba(56,189,248,0.9), transparent);
-            animation:scan 5.5s ease-in-out infinite;
+            inset:0;
+            pointer-events:none;
+            background:radial-gradient(circle at 0% 0%, rgba(56,189,248,0.45), transparent 55%);
+            opacity:0.45;
         }
-        @keyframes scan {
-            0%, 100% {transform:translateY(0); opacity:0;}
-            10% {opacity:0.85;}
-            50% {transform:translateY(180px); opacity:1;}
-            90% {opacity:0.1;}
+        .pm-auth-card h2 {
+            font-size:2rem;
+            margin-bottom:0.45rem;
         }
-        @keyframes haloOrbit {
-            0% {transform:rotate(0deg);} 100% {transform:rotate(360deg);}
+        .pm-auth-card p {color:rgba(226,232,240,0.8);}
+        .pm-auth-card small {
+            text-transform:uppercase;
+            letter-spacing:0.28em;
+            color:rgba(148,163,184,0.9);
         }
-        .pm-auth-card .pm-auth-meta {margin-bottom:1rem;}
-        .pm-auth-card .pm-auth-meta span {letter-spacing:0.24em; text-transform:uppercase; font-size:0.72rem; color:rgba(148,163,184,0.75);}
-        .pm-auth-divider {
-            height:1px;
-            width:100%;
-            background:linear-gradient(90deg, transparent, rgba(56,189,248,0.4), transparent);
-            margin:1.2rem 0 1.6rem;
+        .pm-login-meta {
+            margin:1.4rem 0 1.8rem;
+            display:grid;
+            grid-template-columns:repeat(2, minmax(0, 1fr));
+            gap:0.85rem;
         }
-        .pm-auth-footnote {font-size:0.85rem; color:rgba(226,232,240,0.72); margin-top:1.4rem;}
+        .pm-login-chip {
+            border-radius:18px;
+            padding:0.65rem 0.85rem;
+            border:1px solid rgba(148,163,184,0.22);
+            background:rgba(15,23,42,0.75);
+            font-size:0.8rem;
+            color:rgba(148,163,184,0.9);
+        }
+        .pm-feature-grid {
+            margin-top:2rem;
+            display:grid;
+            grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
+            gap:1.1rem;
+        }
+        .pm-feature-card {
+            padding:1.35rem;
+            border-radius:22px;
+            border:1px solid rgba(59,130,246,0.25);
+            background:rgba(15,23,42,0.7);
+            min-height:180px;
+            box-shadow:0 35px 95px -60px rgba(59,130,246,0.75);
+        }
+        .pm-feature-card h3 {
+            font-size:1.05rem;
+            margin-bottom:0.45rem;
+        }
+        .pm-feature-card p {
+            font-size:0.9rem;
+            color:rgba(226,232,240,0.85);
+        }
+        .pm-auth-card form label {font-weight:600; letter-spacing:0.05em;}
+        .pm-auth-card form input {
+            border-radius:14px !important;
+            background:rgba(2,6,23,0.75);
+            border:1px solid rgba(148,163,184,0.35);
+        }
         </style>
         """,
         unsafe_allow_html=True,
     )
+
+    st.markdown("<div class='pm-landing-grid'>", unsafe_allow_html=True)
 
     hero_col, form_col = st.columns([0.6, 0.4])
 
     with hero_col:
         st.markdown(
             """
-            <div class="pm-hero-wrapper">
-                <div class="pm-hero-section">
-                    <div class="pm-hero-copy">
-                        <div class="eyebrow">The new</div>
-                        <h1>Artificial Intelligence <span>Platform</span></h1>
-                        <p>
-                            Leverage adaptive lesson plans, generative sandboxes, and mentor-grade insights to
-                            accelerate your Python mastery.
-                        </p>
-                        <div class="pm-hero-actions">
-                            <a class="primary" href="#">Read more</a>
-                            <div class="ghost">Immersive lab access</div>
-                        </div>
-                        <div class="pm-hero-stats">
-                            <div class="stat">
-                                <strong>24/7</strong>
-                                <span>AI mentor access</span>
-                            </div>
-                            <div class="stat">
-                                <strong>+180</strong>
-                                <span>Interactive projects</span>
-                            </div>
-                            <div class="stat">
-                                <strong>92%</strong>
-                                <span>Learner success</span>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="pm-hero-visual">
-                        <div class="frame">
-                            <div class="avatar"></div>
-                            <div class="halo"></div>
-                            <div class="scanner"></div>
-                            <div class="wave"></div>
-                        </div>
-                    </div>
+            <div class="pm-landing-hero">
+                <div class="pm-hero-badge">Immersive learning OS</div>
+                <h1>Command your <span>Python journey</span> with cinematic clarity.</h1>
+                <p class="pm-hero-subcopy">
+                    Adaptive cohorts, AI copilots, and production-grade sandboxes converge into one
+                    beautiful timeline. Sign in to continue exactly where you left off.
+                </p>
+                <div class="pm-hero-cards">
+                    <div class="pm-hero-card"><strong>+210</strong><span>hands-on missions</span></div>
+                    <div class="pm-hero-card"><strong>12ms</strong><span>feedback latency</span></div>
+                    <div class="pm-hero-card"><strong>Global</strong><span>talent network</span></div>
+                </div>
+                <div class="pm-hero-cta">
+                    <a class="primary" href="#">Preview experience</a>
+                    <a href="#">Watch lab tour</a>
                 </div>
             </div>
             """,
@@ -238,42 +220,79 @@ def render(auth_manager: AuthManager) -> None:
         st.markdown(
             """
             <div class="pm-auth-card">
-                <h2>Welcome back, innovator</h2>
-                <p>Sign in to sync your intelligent tutoring threads, adaptive studio workspaces, and real-time analytics.</p>
-                <div class="pm-auth-meta"><span>Secure · Encrypted · Personalised</span></div>
+                <small>Encrypted portal</small>
+                <h2>Access mission control</h2>
+                <p>Use your personal call-sign (e.g. <strong>Thor11</strong>) or the email/phone linked to your profile.</p>
+            """,
+            unsafe_allow_html=True,
+        )
+
+        st.markdown(
+            """
+            <div class="pm-login-meta">
+                <div class="pm-login-chip">SAML security &amp; anomaly guard</div>
+                <div class="pm-login-chip">Biometric-ready sessions</div>
+            </div>
             """,
             unsafe_allow_html=True,
         )
 
         with st.form("login-form", clear_on_submit=False):
-            email = st.text_input("Email address", placeholder="you@example.com")
-            password = st.text_input("Password", type="password", placeholder="Your secret passphrase")
-            submitted = st.form_submit_button("Sign in", use_container_width=True)
-
-        st.markdown("<div class='pm-auth-divider'></div>", unsafe_allow_html=True)
+            identifier = st.text_input(
+                "User ID, email, or phone",
+                placeholder="Thor11 / you@example.com / +1 555 123 4567",
+            )
+            password = st.text_input(
+                "Password",
+                type="password",
+                placeholder="••••••••",
+            )
+            st.checkbox("Keep me signed in on this device", value=True, key="pm-login-remember")
+            submitted = st.form_submit_button("Enter workspace", use_container_width=True)
 
         if submitted:
-            if not email or not password:
-                st.error("Please provide both email and password.")
+            if not identifier or not password:
+                st.error("Please provide both your unique user ID (or email/phone) and password.")
                 return
 
-            user = auth_manager.login(email=email, password=password)
+            user = auth_manager.login(identifier=identifier, password=password)
             if not user:
-                st.error("We couldn't find an account with those credentials.")
+                st.error("We couldn't find an account that matches those credentials.")
                 return
 
-            st.success(f"Welcome back, {user['name']}! Redirecting to your dashboard...")
+            st.success(f"Welcome back, {user['name']}! Redirecting to your dashboard…")
             st.session_state["current_page"] = "Dashboard"
             rerun()
 
         st.markdown(
             """
             <div class="pm-auth-footnote">
-                New to PyMasters? Jump over to the <strong>Sign Up</strong> page to create your adaptive learning profile.
+                Prefer to experience the immersive onboarding? Switch to the <strong>Sign Up</strong> view — email and phone are optional.
+            </div>
             </div>
             """,
             unsafe_allow_html=True,
         )
 
-        st.markdown("</div>", unsafe_allow_html=True)
+    st.markdown("</div>", unsafe_allow_html=True)
+
+    st.markdown(
+        """
+        <div class="pm-feature-grid">
+            <div class="pm-feature-card">
+                <h3>Intelligent cohorts</h3>
+                <p>Curate squads by skill, timezone, or goal. Each card surfaces mission health in real time.</p>
+            </div>
+            <div class="pm-feature-card">
+                <h3>Generative studio</h3>
+                <p>Spin up image &amp; video sandboxes without leaving the dashboard. Outputs auto-sync to your history.</p>
+            </div>
+            <div class="pm-feature-card">
+                <h3>Pulse analytics</h3>
+                <p>Beautiful learning telemetry cards reveal progress velocity and focus hotspots instantly.</p>
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
 

--- a/pymasters_app/views/profile.py
+++ b/pymasters_app/views/profile.py
@@ -9,45 +9,129 @@ from utils.streamlit_helpers import rerun
 
 def render(*, auth_manager: AuthManager, user: dict[str, str]) -> None:
     """Render the profile management view."""
-    st.write("## Profile")
-    st.caption("Update your personal information and security preferences.")
 
-    with st.form("profile-form"):
-        name = st.text_input("Full name", value=user.get("name", ""))
-        email = st.text_input("Email", value=user.get("email", ""))
-        submitted = st.form_submit_button("Save changes", use_container_width=True)
+    st.markdown(
+        """
+        <style>
+        .pm-profile-grid {display:grid; grid-template-columns:minmax(0, 0.6fr) minmax(0, 0.4fr); gap:2rem;}
+        @media (max-width: 1100px) {.pm-profile-grid {grid-template-columns:1fr;}}
+        .pm-profile-card {
+            padding:2rem;
+            border-radius:28px;
+            border:1px solid rgba(59,130,246,0.35);
+            background:rgba(15,23,42,0.8);
+            box-shadow:0 45px 120px -70px rgba(59,130,246,0.85);
+        }
+        .pm-profile-card h3 {margin-bottom:0.2rem;}
+        .pm-profile-card p {color:rgba(148,163,184,0.92);}
+        .pm-profile-card form label {font-weight:600; letter-spacing:0.04em;}
+        .pm-profile-card form input {
+            border-radius:14px !important;
+            border:1px solid rgba(148,163,184,0.3);
+            background:rgba(2,6,23,0.75);
+        }
+        .pm-security-card {
+            padding:2rem;
+            border-radius:28px;
+            border:1px solid rgba(16,185,129,0.35);
+            background:rgba(6,78,59,0.45);
+        }
+        .pm-security-chip {
+            display:inline-flex;
+            align-items:center;
+            gap:0.35rem;
+            padding:0.25rem 0.9rem;
+            border-radius:999px;
+            border:1px solid rgba(45,212,191,0.5);
+            text-transform:uppercase;
+            letter-spacing:0.3em;
+            font-size:0.68rem;
+            color:#ccfbf1;
+        }
+        .pm-danger-card {
+            margin-top:1.5rem;
+            padding:1.5rem;
+            border-radius:24px;
+            border:1px solid rgba(248,113,113,0.4);
+            background:rgba(127,29,29,0.35);
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
 
-    if submitted:
-        ok, message, updated_user = auth_manager.update_profile(user["id"], name=name, email=email)
-        if not ok:
-            st.error(message or "We couldn't update your profile right now.")
-        else:
-            st.success("Profile updated successfully.")
-            if updated_user:
-                st.session_state["user"] = updated_user
-            rerun()
+    st.markdown(
+        """
+        <div style="margin-bottom:1.2rem;">
+            <div class="pm-security-chip">Identity Center</div>
+            <h2 style="margin-top:0.6rem;">Profile &amp; Security</h2>
+            <p>Maintain your cinematic call-sign, update contact signals, and tighten your password hygiene.</p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
 
-    st.markdown("### Change password")
-    with st.form("password-form", clear_on_submit=True):
-        current_password = st.text_input("Current password", type="password")
-        new_password = st.text_input("New password", type="password")
-        confirm_password = st.text_input("Confirm new password", type="password")
-        password_submitted = st.form_submit_button("Update password", use_container_width=True)
+    st.markdown("<div class='pm-profile-grid'>", unsafe_allow_html=True)
 
-    if password_submitted:
-        if not current_password or not new_password:
-            st.error("Please complete all fields.")
-        elif new_password != confirm_password:
-            st.error("Your new passwords do not match.")
-        else:
-            ok, message = auth_manager.change_password(
-                user["id"], current_password=current_password, new_password=new_password
+    with st.container():
+        st.markdown("<div class='pm-profile-card'>", unsafe_allow_html=True)
+        with st.form("profile-form"):
+            name = st.text_input("Full name", value=user.get("name", ""))
+            username = st.text_input("User ID", value=user.get("username", ""), help="Visible to peers & used for login")
+            email = st.text_input("Email (optional)", value=user.get("email", ""))
+            phone = st.text_input("Phone (optional)", value=user.get("phone", ""))
+            submitted = st.form_submit_button("Save profile", use_container_width=True)
+
+        if submitted:
+            ok, message, updated_user = auth_manager.update_profile(
+                user["id"],
+                name=name,
+                username=username,
+                email=email or None,
+                phone=phone or None,
             )
             if not ok:
-                st.error(message or "Unable to change the password right now.")
+                st.error(message or "We couldn't update your profile right now.")
             else:
-                st.success("Password updated successfully.")
+                st.success("Profile updated successfully.")
+                if updated_user:
+                    st.session_state["user"] = updated_user
+                rerun()
+        st.markdown("</div>", unsafe_allow_html=True)
 
-    st.markdown("### Danger zone")
-    st.info("Need to sign out? Use the **Sign out** button in the header to end your session.")
+    with st.container():
+        st.markdown("<div class='pm-security-card'>", unsafe_allow_html=True)
+        st.markdown("### Change password", unsafe_allow_html=True)
+        with st.form("password-form", clear_on_submit=True):
+            current_password = st.text_input("Current password", type="password")
+            new_password = st.text_input("New password", type="password")
+            confirm_password = st.text_input("Confirm new password", type="password")
+            password_submitted = st.form_submit_button("Update password", use_container_width=True)
+
+        if password_submitted:
+            if not current_password or not new_password:
+                st.error("Please complete all fields.")
+            elif new_password != confirm_password:
+                st.error("Your new passwords do not match.")
+            else:
+                ok, message = auth_manager.change_password(
+                    user["id"], current_password=current_password, new_password=new_password
+                )
+                if not ok:
+                    st.error(message or "Unable to change the password right now.")
+                else:
+                    st.success("Password updated successfully.")
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    st.markdown("</div>", unsafe_allow_html=True)
+
+    st.markdown(
+        """
+        <div class="pm-danger-card">
+            <h4>Danger zone</h4>
+            <p>Need to sign out everywhere? Use the <strong>Sign out</strong> control in the global header to invalidate all sessions.</p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
 

--- a/pymasters_app/views/signup.py
+++ b/pymasters_app/views/signup.py
@@ -1,40 +1,187 @@
 """Signup page."""
 from __future__ import annotations
 
+import re
+
 import streamlit as st
 
 from pymasters_app.utils.auth import AuthManager
 from utils.streamlit_helpers import rerun
 
 
+USERNAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]{4,20}$")
+
+
 def render(auth_manager: AuthManager) -> None:
-    """Render signup form."""
-    st.write("## Create your account")
-    st.caption("Set up your profile to track progress and unlock personalised recommendations.")
+    """Render an immersive onboarding experience for new users."""
 
-    with st.form("signup-form", clear_on_submit=False):
-        name = st.text_input("Full name", placeholder="Ada Lovelace")
-        email = st.text_input("Email address", placeholder="ada@example.com")
-        password = st.text_input("Password", type="password")
-        confirm_password = st.text_input("Confirm password", type="password")
-        submitted = st.form_submit_button("Create account", use_container_width=True)
+    st.markdown(
+        """
+        <style>
+        .pm-signup-grid {
+            display:grid;
+            grid-template-columns:minmax(0, 0.42fr) minmax(0, 0.58fr);
+            gap:2.2rem;
+            margin-top:1.4rem;
+        }
+        @media (max-width: 1100px) {
+            .pm-signup-grid {grid-template-columns:1fr;}
+        }
+        .pm-signup-hero {
+            padding:2.5rem;
+            border-radius:32px;
+            background:linear-gradient(160deg, rgba(30,64,175,0.25), rgba(15,23,42,0.85));
+            border:1px solid rgba(99,102,241,0.35);
+            box-shadow:0 55px 160px -85px rgba(99,102,241,0.8);
+        }
+        .pm-signup-hero h2 {font-size:2.4rem; margin-bottom:0.6rem;}
+        .pm-signup-hero p {color:rgba(226,232,240,0.85); font-size:1.05rem;}
+        .pm-hero-stack {
+            margin-top:2rem;
+            display:flex;
+            flex-direction:column;
+            gap:1rem;
+        }
+        .pm-hero-card {
+            padding:1rem 1.2rem;
+            border-radius:20px;
+            border:1px solid rgba(148,163,184,0.25);
+            background:rgba(15,23,42,0.72);
+        }
+        .pm-hero-card strong {display:block; font-size:1.1rem; margin-bottom:0.2rem;}
+        .pm-hero-card span {font-size:0.88rem; color:rgba(148,163,184,0.9);}
+        .pm-form-card {
+            padding:2.5rem;
+            border-radius:32px;
+            border:1px solid rgba(56,189,248,0.35);
+            background:linear-gradient(150deg, rgba(8,47,73,0.9), rgba(2,6,23,0.88));
+            box-shadow:0 55px 140px -75px rgba(14,165,233,0.85);
+        }
+        .pm-form-card h3 {font-size:2rem; margin-bottom:0.8rem;}
+        .pm-form-card form label {font-weight:600; letter-spacing:0.04em;}
+        .pm-form-card form input {
+            border-radius:14px !important;
+            border:1px solid rgba(148,163,184,0.32);
+            background:rgba(2,6,23,0.75);
+        }
+        .pm-plan-grid {
+            margin-top:2rem;
+            display:grid;
+            grid-template-columns:repeat(auto-fit, minmax(210px, 1fr));
+            gap:1rem;
+        }
+        .pm-plan-card {
+            padding:1.15rem 1.3rem;
+            border-radius:20px;
+            border:1px solid rgba(59,130,246,0.35);
+            background:rgba(15,23,42,0.7);
+            min-height:180px;
+        }
+        .pm-plan-card h4 {margin-bottom:0.4rem;}
+        .pm-plan-card p {font-size:0.9rem; color:rgba(226,232,240,0.85);}
+        .pm-footnote {margin-top:1.2rem; color:rgba(148,163,184,0.95); font-size:0.9rem;}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
 
-    if submitted:
-        if not all([name, email, password, confirm_password]):
-            st.error("Please complete all fields to continue.")
-            return
-        if password != confirm_password:
-            st.error("Your passwords do not match. Try again.")
-            return
+    st.markdown("<div class='pm-signup-grid'>", unsafe_allow_html=True)
+    hero_col, form_col = st.columns([0.42, 0.58])
 
-        ok, user, message = auth_manager.signup(name=name, email=email, password=password)
-        if not ok or not user:
-            st.error(message or "Unable to create the account. Please try again later.")
-            return
+    with hero_col:
+        st.markdown(
+            """
+            <div class="pm-signup-hero">
+                <p style="letter-spacing:0.35em; text-transform:uppercase; color:#a5b4fc;">Origin story</p>
+                <h2>Craft your PyMasters identity.</h2>
+                <p>
+                    Choose a cinematic user ID (think <strong>IAmIronMan</strong>) and unlock personalised roadmaps,
+                    synced sandboxes, and telemetry-rich dashboards. Email + phone remain optional at every stage.
+                </p>
+                <div class="pm-hero-stack">
+                    <div class="pm-hero-card">
+                        <strong>Unified Passport</strong>
+                        <span>Use one call-sign across tutor, studio, and analytics.</span>
+                    </div>
+                    <div class="pm-hero-card">
+                        <strong>Privacy-first</strong>
+                        <span>Provide email/phone only if you want progress notifications.</span>
+                    </div>
+                    <div class="pm-hero-card">
+                        <strong>Instant progression</strong>
+                        <span>Cards surface your missions the moment you land in the dashboard.</span>
+                    </div>
+                </div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
 
-        st.success(f"Welcome aboard, {user['name']}! Redirecting you to the dashboard...")
-        st.session_state["current_page"] = "Dashboard"
-        rerun()
+    with form_col:
+        st.markdown(
+            """
+            <div class="pm-form-card">
+                <h3>Secure your access badge</h3>
+                <p>All we require is your name, a unique user ID, and a password. Email and phone are optional signals.</p>
+            """,
+            unsafe_allow_html=True,
+        )
 
-    st.divider()
-    st.info("Already have an account? Head to the **Login** page to sign in.")
+        with st.form("signup-form", clear_on_submit=False):
+            name = st.text_input("Full name", placeholder="Ada Lovelace")
+            username = st.text_input("User ID", placeholder="Thor11", help="4-20 characters. Letters, numbers, dots, dashes.")
+            email = st.text_input("Email (optional)", placeholder="ada@example.com")
+            phone = st.text_input("Phone (optional)", placeholder="+1 415 555 0111")
+            password = st.text_input("Password", type="password", placeholder="Create a strong password")
+            confirm_password = st.text_input("Confirm password", type="password", placeholder="Re-enter password")
+            submitted = st.form_submit_button("Launch profile", use_container_width=True)
+
+        if submitted:
+            if not all([name.strip(), username.strip(), password, confirm_password]):
+                st.error("Name, user ID, and password fields are required.")
+                return
+            if not USERNAME_PATTERN.match(username.strip()):
+                st.error("User IDs must be 4-20 characters and can include letters, numbers, dots, underscores, or dashes.")
+                return
+            if password != confirm_password:
+                st.error("Your passwords do not match. Try again.")
+                return
+
+            ok, user, message = auth_manager.signup(
+                name=name,
+                username=username,
+                password=password,
+                email=email or None,
+                phone=phone or None,
+            )
+            if not ok or not user:
+                st.error(message or "Unable to create the account. Please try again later.")
+                return
+
+            st.success(f"Welcome aboard, {user['name']}! Redirecting you to the dashboard…")
+            st.session_state["current_page"] = "Dashboard"
+            rerun()
+
+        st.markdown(
+            """
+            <div class="pm-plan-grid">
+                <div class="pm-plan-card">
+                    <h4>Velocity card</h4>
+                    <p>Shows your streaks, completion rate, and AI tutor insights instantly.</p>
+                </div>
+                <div class="pm-plan-card">
+                    <h4>Studio locker</h4>
+                    <p>All generated assets are tucked into a single secure card for quick playback.</p>
+                </div>
+                <div class="pm-plan-card">
+                    <h4>Signal alerts</h4>
+                    <p>Enable email/phone alerts later if you want nudges — zero pressure.</p>
+                </div>
+            </div>
+            <div class="pm-footnote">Already have a badge? Switch to the <strong>Login</strong> view.</div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    st.markdown("</div>", unsafe_allow_html=True)

--- a/pymasters_app/views/studio.py
+++ b/pymasters_app/views/studio.py
@@ -77,7 +77,7 @@ def render(*, user: dict[str, Any]) -> None:
             # persist metadata
             db["generations"].insert_one(
                 {
-                    "user_id": user.get("_id") if user else None,
+                    "user_id": user.get("id") if user else None,
                     "user_email": user.get("email") if user else None,
                     "task": task.lower(),
                     "model": model,


### PR DESCRIPTION
## Summary
- add a resilient JSON-backed local database fallback and extend the auth layer to support unique usernames plus optional email/phone flows
- redesign the login, signup, dashboard, and profile screens with immersive hero sections and card-based UX, aligning with the new identity-first onboarding flow
- ensure signup/login validation, module cards, and profile management all leverage the upgraded styling and username-centric authentication while keeping studio history intact

## Testing
- `pytest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153e2513e48328aa08b1b380468aad)