### PR TITLE
Improve offline database fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.db
 .venv
 generated/
+.pymasters_localdb/
 **/__pycache__/
 .venv/
 .env*


### PR DESCRIPTION
## Summary
- wrap the Streamlit database bootstrap logic in a helper so we only stop the app when the database itself fails to initialize and surface a clear notice when the local JSON datastore is being used as the offline fallback
- log unexpected bootstrap errors with `st.exception` to aid debugging instead of reusing the "missing Mongo" message
- ignore the generated `.pymasters_localdb/` folder so the encrypted local datastore is never committed

## Testing
- `python - <<'PY'
import pymasters_app.main as main
print(bool(main.db))
PY`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69154f01ed58832884f0b3fade3f8471)