### PR TITLE
Refresh auth landing experience for Python learners

### DIFF
--- a/pymasters_app/components/header.py
+++ b/pymasters_app/components/header.py
@@ -157,7 +157,7 @@ def render_header(
                         <div>
                             <div class="pm-meta-chip">Next-Gen Python</div>
                             <h3 class="title">PyMasters</h3>
-                            <div class="subtitle">AI enhanced learning studio</div>
+                            <div class="subtitle">AI-guided Python learning lab</div>
                         </div>
                     </div>
                 </div>

--- a/pymasters_app/views/login.py
+++ b/pymasters_app/views/login.py
@@ -9,24 +9,20 @@ from utils.streamlit_helpers import rerun
 
 LOGIN_STYLES = """
 <style>
-.pm-login-layout {margin-top:1.5rem;}
+.pm-login-shell {margin-top:1.2rem;}
 .pm-login-hero {
-    padding:2.4rem;
-    border-radius:32px;
+    padding:2.2rem;
+    border-radius:28px;
     border:1px solid rgba(56,189,248,0.35);
-    background:linear-gradient(150deg, rgba(8,47,73,0.75), rgba(2,6,23,0.72));
+    background:linear-gradient(155deg, rgba(8,47,73,0.82), rgba(2,6,23,0.85));
     box-shadow:0 45px 140px -90px rgba(56,189,248,0.85);
 }
-.pm-login-hero h1 {
-    font-size:2.65rem;
-    line-height:1.1;
-    margin:1.1rem 0 0.6rem;
-}
+.pm-login-hero h1 {font-size:2.5rem; line-height:1.08; margin:0.9rem 0 0.5rem;}
 .pm-login-hero h1 span {color:#38bdf8;}
 .pm-login-hero p {color:rgba(241,245,249,0.9); font-size:1rem;}
 .pm-login-hero .pm-hero-badge {
     display:inline-flex;
-    padding:0.35rem 0.9rem;
+    padding:0.32rem 0.8rem;
     border-radius:999px;
     border:1px solid rgba(94,234,212,0.4);
     text-transform:uppercase;
@@ -34,109 +30,70 @@ LOGIN_STYLES = """
     font-size:0.72rem;
     color:#bbf7d0;
 }
-.pm-login-metrics {
-    margin-top:1.8rem;
-    display:grid;
-    grid-template-columns:repeat(auto-fit, minmax(160px, 1fr));
-    gap:1rem;
-}
-.pm-login-metric {
-    padding:1rem 1.2rem;
-    border-radius:20px;
+.pm-login-grid {display:grid; grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); gap:0.9rem; margin-top:1.6rem;}
+.pm-login-card {
+    padding:1rem 1.1rem;
+    border-radius:18px;
     border:1px solid rgba(148,163,184,0.25);
-    background:rgba(15,23,42,0.7);
+    background:rgba(15,23,42,0.74);
 }
-.pm-login-metric strong {
-    font-size:1.5rem;
-    display:block;
-    color:#f8fafc;
+.pm-login-card strong {display:block; font-size:1.35rem; color:#f8fafc;}
+.pm-login-card span {font-size:0.82rem; letter-spacing:0.18em; text-transform:uppercase; color:rgba(148,163,184,0.85);}
+.pm-ai-prompts {margin-top:1.4rem; display:grid; grid-template-columns:repeat(auto-fit, minmax(200px, 1fr)); gap:0.85rem;}
+.pm-ai-prompts .prompt {
+    padding:0.85rem 1rem;
+    border-radius:16px;
+    border:1px solid rgba(148,163,184,0.32);
+    background:rgba(2,6,23,0.78);
+    color:#e2e8f0;
+    font-size:0.9rem;
 }
-.pm-login-metric span {
-    font-size:0.8rem;
-    letter-spacing:0.2em;
-    text-transform:uppercase;
-    color:rgba(148,163,184,0.85);
-}
+.pm-ai-prompts .prompt code {color:#38bdf8;}
 form[data-testid="stForm"][aria-label="login-form"] {
-    padding:2.2rem;
-    border-radius:30px;
+    padding:2.1rem;
+    border-radius:28px;
     border:1px solid rgba(56,189,248,0.35);
     background:linear-gradient(150deg, rgba(15,23,42,0.92), rgba(2,6,23,0.88));
     box-shadow:0 45px 120px -80px rgba(14,165,233,0.7);
 }
-form[data-testid="stForm"][aria-label="login-form"] label {
-    font-weight:600;
-    letter-spacing:0.04em;
-}
-form[data-testid="stForm"][aria-label="login-form"] input {
-    border-radius:14px !important;
-    border:1px solid rgba(148,163,184,0.35);
-    background:rgba(15,23,42,0.75);
-}
-.pm-login-meta {
-    display:flex;
-    flex-wrap:wrap;
-    gap:0.45rem;
-    margin:0.85rem 0 1.1rem;
-}
-.pm-login-chip {
-    padding:0.35rem 0.85rem;
-    border-radius:999px;
-    border:1px solid rgba(148,163,184,0.35);
-    background:rgba(15,23,42,0.8);
-    font-size:0.75rem;
-    letter-spacing:0.12em;
-    color:#e2e8f0;
-}
-.pm-feature-grid {
-    margin-top:2.5rem;
-    display:grid;
-    grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
-    gap:1.2rem;
-}
-.pm-feature-card {
-    padding:1.4rem 1.6rem;
-    border-radius:22px;
-    border:1px solid rgba(148,163,184,0.25);
-    background:rgba(15,23,42,0.82);
-    box-shadow:0 35px 90px -70px rgba(8,145,178,0.65);
-}
-.pm-feature-card h3 {margin-bottom:0.35rem;}
-.pm-feature-card p {color:rgba(226,232,240,0.85); font-size:0.92rem;}
+form[data-testid="stForm"][aria-label="login-form"] label {font-weight:600; letter-spacing:0.03em;}
+form[data-testid="stForm"][aria-label="login-form"] input {border-radius:14px !important; border:1px solid rgba(148,163,184,0.35); background:rgba(15,23,42,0.75);}
+.pm-login-meta {display:flex; flex-wrap:wrap; gap:0.45rem; margin:0.8rem 0 1rem;}
+.pm-login-chip {padding:0.35rem 0.85rem; border-radius:999px; border:1px solid rgba(148,163,184,0.35); background:rgba(15,23,42,0.8); font-size:0.75rem; letter-spacing:0.12em; color:#e2e8f0;}
+.pm-feature-grid {margin-top:2.2rem; display:grid; grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); gap:1.1rem;}
+.pm-feature-card {padding:1.25rem 1.35rem; border-radius:20px; border:1px solid rgba(148,163,184,0.25); background:rgba(15,23,42,0.82); box-shadow:0 35px 90px -70px rgba(8,145,178,0.65);}
+.pm-feature-card h3 {margin-bottom:0.25rem;}
+.pm-feature-card p {color:rgba(226,232,240,0.85); font-size:0.9rem;}
 </style>
 """
 
 
 def render(auth_manager: AuthManager) -> None:
-    """Render a cinematic landing page with a streamlined login form."""
+    """Render a focused landing page with clear login guidance."""
 
     st.markdown(LOGIN_STYLES, unsafe_allow_html=True)
 
-    hero_col, form_col = st.columns([0.58, 0.42], gap="large")
+    hero_col, form_col = st.columns([0.56, 0.44], gap="large")
 
     with hero_col:
         st.markdown(
             """
-            <section class="pm-login-layout pm-login-hero">
-                <div class="pm-hero-badge">Immersive learning OS</div>
-                <h1>Command your <span>Python journey</span> with clarity.</h1>
+            <section class="pm-login-shell pm-login-hero">
+                <div class="pm-hero-badge">Python mission control</div>
+                <h1>Land in a <span>Python-first cockpit</span> powered by AI.</h1>
                 <p>
-                    Adaptive cohorts, AI copilots, and production-grade sandboxes converge into one
-                    beautiful timeline. Sign in to continue exactly where you left off.
+                    Every screen is tuned for Python: concise briefs, runnable practice, and an AI Instructor
+                    that answers with code-ready snippets. Log in to pick up the exact lesson or sandbox you paused.
                 </p>
-                <div class="pm-login-metrics">
-                    <div class="pm-login-metric">
-                        <strong>+210</strong>
-                        <span>Missions</span>
-                    </div>
-                    <div class="pm-login-metric">
-                        <strong>12 ms</strong>
-                        <span>Feedback</span>
-                    </div>
-                    <div class="pm-login-metric">
-                        <strong>Global</strong>
-                        <span>Network</span>
-                    </div>
+                <div class="pm-login-grid">
+                    <div class="pm-login-card"><strong>Instant fixes</strong><span>AI Tutor</span></div>
+                    <div class="pm-login-card"><strong>Practice labs</strong><span>Playground</span></div>
+                    <div class="pm-login-card"><strong>Path clarity</strong><span>Roadmaps</span></div>
+                </div>
+                <div class="pm-ai-prompts">
+                    <div class="prompt">Ask: <code>Explain list comprehensions with 2 examples</code></div>
+                    <div class="prompt">Try: <code>Draft a pytest for my function</code></div>
+                    <div class="prompt">Explore: <code>What should I learn after dictionaries?</code></div>
                 </div>
             </section>
             """,
@@ -146,9 +103,9 @@ def render(auth_manager: AuthManager) -> None:
     with form_col:
         st.markdown(
             """
-            <section class="pm-login-layout">
-                <h2>Access mission control</h2>
-                <p>Your cinematic user ID (e.g. <strong>Thor11</strong>) is the only credential required.</p>
+            <section class="pm-login-shell">
+                <h2>Sign in to your track</h2>
+                <p>Use your PyMasters ID and password. We keep the flow minimal so you can jump straight into Python.</p>
             </section>
             """,
             unsafe_allow_html=True,
@@ -157,9 +114,9 @@ def render(auth_manager: AuthManager) -> None:
         st.markdown(
             """
             <div class="pm-login-meta">
-                <div class="pm-login-chip">SAML ready</div>
-                <div class="pm-login-chip">Anomaly guard</div>
-                <div class="pm-login-chip">Biometric aware</div>
+                <div class="pm-login-chip">AI Instructor</div>
+                <div class="pm-login-chip">Hands-on Tutor</div>
+                <div class="pm-login-chip">Secure workspace</div>
             </div>
             """,
             unsafe_allow_html=True,
@@ -168,7 +125,7 @@ def render(auth_manager: AuthManager) -> None:
         with st.form("login-form", clear_on_submit=False):
             identifier = st.text_input(
                 "User ID",
-                placeholder="Thor11 / valkyrie",
+                placeholder="e.g. pythonista7",
             )
             password = st.text_input(
                 "Password",
@@ -183,7 +140,13 @@ def render(auth_manager: AuthManager) -> None:
                 st.error("Please provide both your unique user ID and password.")
                 return
 
-            user = auth_manager.login(identifier=identifier, password=password)
+            try:
+                user = auth_manager.login(identifier=identifier, password=password)
+            except Exception as exc:  # pragma: no cover - defensive guard for UI flow
+                st.error("Login failed unexpectedly. Please try again.")
+                st.exception(exc)
+                return
+
             if not user:
                 st.error("We couldn't find an account with that user ID and password.")
                 return
@@ -193,23 +156,23 @@ def render(auth_manager: AuthManager) -> None:
             rerun()
 
         st.caption(
-            "Prefer the immersive onboarding? Switch to **Sign Up** – email and phone remain optional."
+            "New to PyMasters? Switch to **Sign Up** to create your ID and meet the AI Instructor."
         )
 
     st.markdown(
         """
         <div class="pm-feature-grid">
             <div class="pm-feature-card">
-                <h3>Intelligent cohorts</h3>
-                <p>Curate squads by skill, timezone, or goal. Each card surfaces mission health in real time.</p>
+                <h3>Guided playlists</h3>
+                <p>Short, linked Python lessons that keep context tight and reduce switching costs.</p>
             </div>
             <div class="pm-feature-card">
-                <h3>Generative studio</h3>
-                <p>Spin up image and video sandboxes without leaving the dashboard. Outputs auto-sync to your history.</p>
+                <h3>AI answers with code</h3>
+                <p>The AI Tutor responds with runnable snippets, tests, and quick refactors tailored to your level.</p>
             </div>
             <div class="pm-feature-card">
-                <h3>Pulse analytics</h3>
-                <p>Beautiful learning telemetry cards reveal progress velocity and focus hotspots instantly.</p>
+                <h3>Playground ready</h3>
+                <p>Open the sandbox to validate a concept immediately after learning it—no extra setup.</p>
             </div>
         </div>
         """,

--- a/pymasters_app/views/signup.py
+++ b/pymasters_app/views/signup.py
@@ -13,62 +13,22 @@ USERNAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]{4,20}$")
 
 SIGNUP_STYLES = """
 <style>
-.pm-signup-hero, .pm-signup-form {
-    margin-top:1.4rem;
-    border-radius:32px;
-    border:1px solid rgba(99,102,241,0.35);
-    padding:2.4rem;
-}
-.pm-signup-hero {
-    background:linear-gradient(160deg, rgba(30,64,175,0.25), rgba(15,23,42,0.85));
-    box-shadow:0 55px 160px -85px rgba(99,102,241,0.8);
-}
-.pm-signup-hero h2 {font-size:2.4rem; margin-bottom:0.6rem;}
-.pm-signup-hero p {color:rgba(226,232,240,0.85); font-size:1.05rem;}
-.pm-hero-stack {
-    margin-top:2rem;
-    display:flex;
-    flex-direction:column;
-    gap:1rem;
-}
-.pm-hero-card {
-    padding:1rem 1.2rem;
-    border-radius:20px;
-    border:1px solid rgba(148,163,184,0.25);
-    background:rgba(15,23,42,0.72);
-}
-.pm-hero-card strong {display:block; font-size:1.1rem; margin-bottom:0.2rem;}
+.pm-signup-hero, .pm-signup-form {margin-top:1.3rem; border-radius:30px; border:1px solid rgba(99,102,241,0.35); padding:2.2rem;}
+.pm-signup-hero {background:linear-gradient(160deg, rgba(30,64,175,0.28), rgba(15,23,42,0.85)); box-shadow:0 55px 160px -85px rgba(99,102,241,0.8);}
+.pm-signup-hero h2 {font-size:2.35rem; margin-bottom:0.55rem;}
+.pm-signup-hero p {color:rgba(226,232,240,0.88); font-size:1.02rem;}
+.pm-hero-stack {margin-top:1.8rem; display:flex; flex-direction:column; gap:0.95rem;}
+.pm-hero-card {padding:1rem 1.15rem; border-radius:20px; border:1px solid rgba(148,163,184,0.25); background:rgba(15,23,42,0.72);}
+.pm-hero-card strong {display:block; font-size:1.05rem; margin-bottom:0.2rem;}
 .pm-hero-card span {font-size:0.88rem; color:rgba(148,163,184,0.9);}
-.pm-signup-form {
-    border:1px solid rgba(56,189,248,0.35);
-    background:linear-gradient(150deg, rgba(8,47,73,0.9), rgba(2,6,23,0.88));
-    box-shadow:0 55px 140px -75px rgba(14,165,233,0.85);
-}
-form[data-testid="stForm"][aria-label="signup-form"] label {
-    font-weight:600;
-    letter-spacing:0.04em;
-}
-form[data-testid="stForm"][aria-label="signup-form"] input {
-    border-radius:14px !important;
-    border:1px solid rgba(148,163,184,0.32);
-    background:rgba(2,6,23,0.75);
-}
-.pm-plan-grid {
-    margin-top:2rem;
-    display:grid;
-    grid-template-columns:repeat(auto-fit, minmax(210px, 1fr));
-    gap:1rem;
-}
-.pm-plan-card {
-    padding:1.15rem 1.3rem;
-    border-radius:20px;
-    border:1px solid rgba(59,130,246,0.35);
-    background:rgba(15,23,42,0.7);
-    min-height:180px;
-}
-.pm-plan-card h4 {margin-bottom:0.35rem;}
+.pm-signup-form {border:1px solid rgba(56,189,248,0.35); background:linear-gradient(150deg, rgba(8,47,73,0.9), rgba(2,6,23,0.88)); box-shadow:0 55px 140px -75px rgba(14,165,233,0.85);}
+form[data-testid="stForm"][aria-label="signup-form"] label {font-weight:600; letter-spacing:0.03em;}
+form[data-testid="stForm"][aria-label="signup-form"] input {border-radius:14px !important; border:1px solid rgba(148,163,184,0.32); background:rgba(2,6,23,0.75);}
+.pm-plan-grid {margin-top:1.9rem; display:grid; grid-template-columns:repeat(auto-fit, minmax(210px, 1fr)); gap:0.95rem;}
+.pm-plan-card {padding:1.1rem 1.2rem; border-radius:20px; border:1px solid rgba(59,130,246,0.35); background:rgba(15,23,42,0.7); min-height:170px;}
+.pm-plan-card h4 {margin-bottom:0.3rem;}
 .pm-plan-card p {font-size:0.9rem; color:rgba(226,232,240,0.85);}
-.pm-footnote {margin-top:1.2rem; color:rgba(148,163,184,0.95); font-size:0.9rem;}
+.pm-footnote {margin-top:1.1rem; color:rgba(148,163,184,0.95); font-size:0.9rem;}
 </style>
 """
 
@@ -78,30 +38,30 @@ def render(auth_manager: AuthManager) -> None:
 
     st.markdown(SIGNUP_STYLES, unsafe_allow_html=True)
 
-    hero_col, form_col = st.columns([0.42, 0.58], gap="large")
+    hero_col, form_col = st.columns([0.44, 0.56], gap="large")
 
     with hero_col:
         st.markdown(
             """
             <section class="pm-signup-hero">
-                <p style="letter-spacing:0.35em; text-transform:uppercase; color:#a5b4fc;">Origin story</p>
-                <h2>Craft your PyMasters identity.</h2>
+                <p style="letter-spacing:0.32em; text-transform:uppercase; color:#a5b4fc;">Start learning Python</p>
+                <h2>Create your PyMasters ID.</h2>
                 <p>
-                    Choose a cinematic user ID (think <strong>IAmIronMan</strong>) and unlock personalised roadmaps,
-                    synced sandboxes, and telemetry-rich dashboards. Email and phone remain optional.
+                    A single sign-in unlocks the AI Instructor, the Tutor, the Playground, and your curated Python roadmaps.
+                    We only need a name, user ID, and password to get you coding quickly.
                 </p>
                 <div class="pm-hero-stack">
                     <div class="pm-hero-card">
-                        <strong>Unified Passport</strong>
-                        <span>Use one call-sign across tutor, studio, and analytics.</span>
+                        <strong>AI-first learning</strong>
+                        <span>Ask for hints, tests, or refactors while you write Python.</span>
                     </div>
                     <div class="pm-hero-card">
-                        <strong>Privacy-first</strong>
-                        <span>Provide email/phone only if you want progress notifications.</span>
+                        <strong>One workspace</strong>
+                        <span>Progress, drafts, and lab history stay synced across every tool.</span>
                     </div>
                     <div class="pm-hero-card">
-                        <strong>Instant progression</strong>
-                        <span>Cards surface your missions the moment you land in the dashboard.</span>
+                        <strong>Optional signals</strong>
+                        <span>Add email or phone later if you want reminders—never required to learn.</span>
                     </div>
                 </div>
             </section>
@@ -114,14 +74,14 @@ def render(auth_manager: AuthManager) -> None:
             """
             <section class="pm-signup-form">
                 <h3>Secure your access badge</h3>
-                <p>All we require is your name, a unique user ID, and a password. Email and phone are optional signals.</p>
+                <p>Keep it simple: name, PyMasters ID, and a password. Email and phone are optional and only used for nudges.</p>
             </section>
             """,
             unsafe_allow_html=True,
         )
 
         st.info(
-            "Remember: your user ID is the only credential used to sign in. Emails and phone numbers are optional for notifications.",
+            "Your PyMasters ID is the single credential for login. Email and phone stay optional until you decide to add them.",
             icon="ℹ️",
         )
 
@@ -129,7 +89,7 @@ def render(auth_manager: AuthManager) -> None:
             name = st.text_input("Full name", placeholder="Ada Lovelace")
             username = st.text_input(
                 "User ID",
-                placeholder="Thor11",
+                placeholder="e.g. pythonista7",
                 help="4-20 characters. Letters, numbers, dots, underscores, or dashes.",
             )
             email = st.text_input("Email (optional)", placeholder="ada@example.com")
@@ -173,16 +133,16 @@ def render(auth_manager: AuthManager) -> None:
             """
             <div class="pm-plan-grid">
                 <div class="pm-plan-card">
-                    <h4>Velocity card</h4>
-                    <p>Shows your streaks, completion rate, and AI tutor insights instantly.</p>
+                    <h4>Guided path</h4>
+                    <p>Follow a Python path that adapts as you complete labs and lessons.</p>
                 </div>
                 <div class="pm-plan-card">
-                    <h4>Studio locker</h4>
-                    <p>All generated assets are tucked into a single secure card for quick playback.</p>
+                    <h4>AI Tutor</h4>
+                    <p>Request examples, bug hunts, or practice drills from the Tutor in natural language.</p>
                 </div>
                 <div class="pm-plan-card">
-                    <h4>Signal alerts</h4>
-                    <p>Enable email or phone alerts later if you want nudges – zero pressure.</p>
+                    <h4>Playground</h4>
+                    <p>Experiment with snippets immediately after you learn a concept—no extra setup.</p>
                 </div>
             </div>
             <div class="pm-footnote">Already have a badge? Switch to the <strong>Login</strong> view.</div>


### PR DESCRIPTION
## Summary
- Rework login and signup pages to emphasize AI-guided, Python-focused onboarding with clearer prompts and layouts
- Update header subtitle to reinforce the app’s AI-guided Python learning positioning

## Testing
- python -m compileall pymasters_app


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4f1e6574832896403f7025e24c22)