### PR TITLE
[Pipeline] New lesson: Understanding LLM Benchmarks: Decode the Open LLM Leaderboard

### DIFF
--- a/backend/lessons/ai_engineering/open_llm_leaderboard_understanding_llm_benchmarks.json
+++ b/backend/lessons/ai_engineering/open_llm_leaderboard_understanding_llm_benchmarks.json
@@ -1,0 +1,217 @@
+{
+  "id": "open_llm_leaderboard_understanding_llm_benchmarks",
+  "topic": "open_llm_leaderboard_understanding_llm_benchmarks",
+  "track": "ai_engineering",
+  "module": "trending_ai",
+  "order": 99,
+  "title": {
+    "en": "Understanding LLM Benchmarks: Decode the Open LLM Leaderboard"
+  },
+  "description": {
+    "en": "Learn what each Open LLM Leaderboard benchmark actually measures, how to query leaderboard results programmatically, and how to build a scoring profile that matches your Homie assistant's real-world needs."
+  },
+  "xp_reward": 65,
+  "next_unlock": null,
+  "story_variants": {
+    "en": "## Understanding LLM Benchmarks: What the Scores Really Mean\n\nVaathiyaar here! Everyone talks about \"the best open model\" â€” but best *at what*? The Open LLM Leaderboard on Hugging Face evaluates models on six benchmarks, and each one tests a fundamentally different capability. Picking a model without understanding the benchmarks is like choosing a car based only on top speed when you need fuel economy. Today, you'll learn to read benchmarks like an engineer, query leaderboard data with Python, and build a **benchmark profile** that maps directly to your Homie assistant's job.\n\n### The Six Benchmarks Decoded\n\nThe leaderboard v2 uses these evaluations, each normalized to 0â€“100:\n\n| Benchmark | Capability Tested | Example Task | Homie Relevance |\n|---|---|---|---|\n| **IFEval** | Instruction following | \"Write exactly 3 bullet points\" | High â€” Homie must follow user formats |\n| **BBH** | Multi-step reasoning | Logic chains, causal inference | High â€” Homie answers complex queries |\n| **MATH Lvl 5** | Advanced mathematics | Algebra, proofs, word problems | Medium â€” depends on user domain |\n| **GPQA** | Graduate-level science QA | PhD-level physics, biology | Low â€” unless Homie serves researchers |\n| **MuSR** | Soft multi-step reasoning | Ambiguous, real-world scenarios | High â€” everyday questions are messy |\n| **MMLU-PRO** | Broad knowledge (57 subjects) | History, law, medicine, CS | High â€” general assistant needs breadth |\n\n### Why Average Score Misleads\n\nThe leaderboard's Average column weights all six benchmarks equally. But your Homie assistant probably doesn't need PhD-level science (GPQA). A model scoring 45 average but 70 on IFEval and BBH may outperform a 55-average model that gets its boost from MATH and GPQA.\n\n```python\ndef benchmark_profile(scores, weights):\n    \"\"\"Compute a use-case-specific score from benchmark data.\"\"\"\n    total = sum(scores.get(b, 0) * w for b, w in weights.items())\n    norm = sum(weights.values())\n    return round(total / norm, 1)\n\n# Homie assistant weights: instruction following + reasoning matter most\nhomie_weights = {\n    \"ifeval\": 0.30, \"bbh\": 0.25, \"musr\": 0.20,\n    \"mmlu_pro\": 0.15, \"math\": 0.05, \"gpqa\": 0.05\n}\n```\n\n### Querying the Leaderboard Programmatically\n\nThe leaderboard results are stored as a Hugging Face dataset. You can load and filter them in Python:\n\n```python\nfrom datasets import load_dataset\n\nds = load_dataset(\n    \"open-llm-leaderboard/contents\", split=\"train\"\n)\n\n# Filter to models under 10B parameters\nsmall = ds.filter(lambda row: (row.get(\"#Params (B)\") or 0) <= 10)\nprint(f\"{len(small)} models with â‰¤10B params\")\n```\n\n### Building a Benchmark Radar\n\nA radar chart shows a model's shape â€” where it excels and where it drops. Two models with the same average can have very different shapes.\n\n```python\ndef radar_summary(name, scores, benchmarks):\n    \"\"\"Print a text radar showing relative strengths.\"\"\"\n    max_bar = 30\n    print(f\"\\n{name}:\")\n    for b in benchmarks:\n        val = scores.get(b, 0)\n        bar = \"â–ˆ\" * int(val / 100 * max_bar)\n        print(f\"  {b:<10} {bar} {val:.1f}\")\n```\n\nThis quickly reveals if a model is a specialist (spiky profile) or generalist (flat profile). For Homie, you usually want a generalist â€” one that doesn't collapse on any single benchmark.\n\n### Red Flags on the Leaderboard\n\n- **Huge gap between IFEval and other scores**: model may be over-fitted to instruction templates\n- **Very high MATH but low BBH**: good at pattern-matching formulas, weak at novel reasoning\n- **Score dramatically above similar-sized models**: possible data contamination â€” check community comments\n\n> **Key Insight:** Benchmarks are proxies, not guarantees. A model's leaderboard score tells you how it performs on *those specific tests* â€” not necessarily on your users' real questions. Use benchmarks to shortlist 2-3 candidates, then test them on YOUR data. The leaderboard narrows the haystack; your evaluation finds the needle."
+  },
+  "animation_sequence": [
+    {
+      "type": "StoryCard",
+      "id": "intro_1",
+      "content": "The Open LLM Leaderboard evaluates models on six benchmarks â€” IFEval, BBH, MATH, GPQA, MuSR, and MMLU-PRO. Each measures a different capability. Understanding what they test lets you build a custom scoring profile that matches your Homie assistant's actual job, instead of blindly trusting the average.",
+      "visual_theme": "modern"
+    },
+    {
+      "type": "CodeStepper",
+      "id": "code_1",
+      "language": "python",
+      "code": "# Benchmark data for three models from the Open LLM Leaderboard\nbenchmarks = [\"ifeval\", \"bbh\", \"math\", \"gpqa\", \"musr\", \"mmlu_pro\"]\n\nmodels = {\n    \"Llama-3.1-8B-Instruct\": {\n        \"ifeval\": 72.3, \"bbh\": 58.1, \"math\": 45.6,\n        \"gpqa\": 31.2, \"musr\": 42.5, \"mmlu_pro\": 48.8\n    },\n    \"Mistral-7B-Instruct-v0.3\": {\n        \"ifeval\": 60.1, \"bbh\": 52.4, \"math\": 35.8,\n        \"gpqa\": 28.5, \"musr\": 40.1, \"mmlu_pro\": 44.3\n    },\n    \"Phi-3-mini-4k\": {\n        \"ifeval\": 55.2, \"bbh\": 45.8, \"math\": 30.5,\n        \"gpqa\": 22.8, \"musr\": 38.7, \"mmlu_pro\": 39.6\n    },\n}\n\n# Compute the simple average (what the leaderboard shows)\nfor name, scores in models.items():\n    avg = round(sum(scores.values()) / len(scores), 1)\n    print(f\"{name:<32} avg={avg}\")",
+      "steps": [
+        {
+          "line": 2,
+          "explanation": "The six benchmark names from the Open LLM Leaderboard v2. Each measures a distinct skill: instruction following, reasoning, math, science, soft reasoning, and broad knowledge."
+        },
+        {
+          "line": 5,
+          "explanation": "Llama-3.1-8B-Instruct: strong on IFEval (72.3) â€” great at following precise instructions. Its BBH (58.1) shows solid reasoning too."
+        },
+        {
+          "line": 9,
+          "explanation": "Mistral-7B: a bit lower across the board than Llama-3.1-8B, but still competitive. The gap is narrower on reasoning (BBH) than on instruction following (IFEval)."
+        },
+        {
+          "line": 13,
+          "explanation": "Phi-3-mini at 3.8B params is much smaller. Scores are lower, but for its size it's impressive. The question is whether those scores are *good enough* for your use case."
+        },
+        {
+          "line": 20,
+          "explanation": "Simple average treats all benchmarks equally. Llama-3.1-8B wins, but this average hides important details â€” like the 41-point gap between its IFEval and GPQA scores."
+        },
+        {
+          "line": 21,
+          "explanation": "The print reveals each model's average. But two models with the same average can have very different capability profiles â€” one might ace math and fail reasoning."
+        }
+      ]
+    },
+    {
+      "type": "CodeStepper",
+      "id": "code_2",
+      "language": "python",
+      "code": "# Custom benchmark weighting for different Homie use cases\ndef weighted_score(scores, weights):\n    \"\"\"Compute a weighted benchmark score, normalized by weight sum.\"\"\"\n    total = sum(scores.get(b, 0) * w for b, w in weights.items())\n    return round(total / sum(weights.values()), 1)\n\n# Profile 1: General Homie assistant\nhomie_general = {\n    \"ifeval\": 0.30, \"bbh\": 0.25, \"musr\": 0.20,\n    \"mmlu_pro\": 0.15, \"math\": 0.05, \"gpqa\": 0.05\n}\n\n# Profile 2: Code tutor Homie\nhomie_code = {\n    \"bbh\": 0.35, \"math\": 0.30, \"ifeval\": 0.20,\n    \"mmlu_pro\": 0.10, \"musr\": 0.05, \"gpqa\": 0.00\n}\n\nprint(f\"{'Model':<32} {'General':>8} {'CodeTutor':>10}\")\nprint(\"-\" * 52)\nfor name, scores in models.items():\n    gen = weighted_score(scores, homie_general)\n    code = weighted_score(scores, homie_code)\n    print(f\"{name:<32} {gen:>8.1f} {code:>10.1f}\")",
+      "steps": [
+        {
+          "line": 2,
+          "explanation": "weighted_score multiplies each benchmark score by its importance weight, then normalizes by total weight. This replaces the equal-weight average with YOUR priorities."
+        },
+        {
+          "line": 4,
+          "explanation": "scores.get(b, 0) handles missing benchmarks gracefully â€” if a model lacks a score, it gets 0 for that benchmark rather than crashing."
+        },
+        {
+          "line": 8,
+          "explanation": "General Homie profile: IFEval (0.30) and BBH (0.25) dominate. GPQA gets only 0.05 â€” a general assistant rarely needs PhD-level science knowledge."
+        },
+        {
+          "line": 14,
+          "explanation": "Code tutor profile: BBH (reasoning) and MATH are king. GPQA is zeroed out entirely â€” irrelevant for coding assistance."
+        },
+        {
+          "line": 20,
+          "explanation": "Side-by-side comparison reveals how the same models rank differently under different profiles. The 'best' model depends entirely on the job it needs to do."
+        },
+        {
+          "line": 22,
+          "explanation": "Llama-3.1-8B likely leads in both profiles because it's strongest on IFEval and BBH. But the gap narrows for code tutoring where Mistral's reasoning is closer."
+        }
+      ]
+    },
+    {
+      "type": "CodeStepper",
+      "id": "code_3",
+      "language": "python",
+      "code": "# Detect benchmark strengths and weaknesses\ndef analyze_profile(name, scores, benchmarks):\n    \"\"\"Identify a model's strongest and weakest benchmarks.\"\"\"\n    sorted_bm = sorted(benchmarks, key=lambda b: scores.get(b, 0), reverse=True)\n    strongest = sorted_bm[0]\n    weakest = sorted_bm[-1]\n    spread = scores[strongest] - scores[weakest]\n    return {\n        \"strongest\": strongest,\n        \"weakest\": weakest,\n        \"spread\": round(spread, 1),\n        \"is_specialist\": spread > 25\n    }\n\n# Analyze all models\nfor name, scores in models.items():\n    profile = analyze_profile(name, scores, benchmarks)\n    label = \"SPECIALIST\" if profile[\"is_specialist\"] else \"GENERALIST\"\n    print(f\"{name}:\")\n    print(f\"  Best:  {profile['strongest']} ({scores[profile['strongest']]:.1f})\")\n    print(f\"  Worst: {profile['weakest']} ({scores[profile['weakest']]:.1f})\")\n    print(f\"  Spread: {profile['spread']} â†’ {label}\")\n\n# Red flag detection: suspiciously high single benchmark\ndef check_red_flags(name, scores, benchmarks):\n    avg = sum(scores[b] for b in benchmarks) / len(benchmarks)\n    flags = []\n    for b in benchmarks:\n        if scores[b] > avg * 1.5:\n            flags.append(f\"{b} is {scores[b]:.0f} vs avg {avg:.0f} â€” possible overfit\")\n    return flags\n\nfor name, scores in models.items():\n    flags = check_red_flags(name, scores, benchmarks)\n    if flags:\n        print(f\"\\nâš  {name}: {'; '.join(flags)}\")\n    else:\n        print(f\"\\nâœ“ {name}: no red flags\")",
+      "steps": [
+        {
+          "line": 2,
+          "explanation": "Profile analysis sorts benchmarks by score to find the model's strongest and weakest areas. The spread (max - min) reveals how lopsided the model is."
+        },
+        {
+          "line": 7,
+          "explanation": "Spread > 25 points flags a specialist model. Specialists excel in one area but may fail unexpectedly in others â€” risky for a general-purpose Homie assistant."
+        },
+        {
+          "line": 12,
+          "explanation": "The is_specialist flag is a quick heuristic. For Homie, you generally want generalists (low spread) unless you're building a domain-specific assistant."
+        },
+        {
+          "line": 17,
+          "explanation": "Looping through models prints a human-readable capability profile. You instantly see that Llama-3.1-8B is a specialist with a 41-point spread between IFEval and GPQA."
+        },
+        {
+          "line": 24,
+          "explanation": "Red flag detector: if any single benchmark score is more than 1.5Ã— the model's own average, it could indicate training data contamination or overfitting to that benchmark format."
+        },
+        {
+          "line": 28,
+          "explanation": "A score 50% above the model's average is suspicious but not conclusive. It warrants checking community discussions on the model's Hugging Face page before trusting it."
+        }
+      ]
+    },
+    {
+      "type": "ComparisonPanel",
+      "id": "comparison_1",
+      "left_label": "Trusting the Average Blindly",
+      "right_label": "Understanding Individual Benchmarks",
+      "items": [
+        {
+          "left": "Sort by Average, pick #1",
+          "right": "Weight benchmarks by your actual use case"
+        },
+        {
+          "left": "Assume all benchmarks matter equally",
+          "right": "Know IFEval matters for assistants, MATH for tutors"
+        },
+        {
+          "left": "Ignore lopsided profiles",
+          "right": "Detect specialists vs generalists via spread analysis"
+        },
+        {
+          "left": "Trust high scores at face value",
+          "right": "Check for red flags and data contamination signals"
+        },
+        {
+          "left": "Never retest on your own data",
+          "right": "Use leaderboard to shortlist, then validate on YOUR tasks"
+        }
+      ]
+    },
+    {
+      "type": "ParticleEffect",
+      "id": "finish_1",
+      "effect": "confetti",
+      "message": "You now understand what each LLM benchmark actually measures and can build custom scoring profiles to pick the right model for your Homie assistant's real-world job!"
+    }
+  ],
+  "practice_challenges": [
+    {
+      "instruction": {
+        "en": "Build a `BenchmarkProfiler` class that analyzes Open LLM Leaderboard results. It should: (1) Accept benchmark names in `__init__(self, benchmarks)` and store models in a dict, (2) Implement `add_model(name, scores)` where scores is a dict mapping benchmark names to float values, (3) Implement `weighted_score(model_name, weights)` returning the weighted score normalized by total weight (rounded to 1 decimal) â€” use 0 for missing benchmarks, (4) Implement `classify(model_name)` returning 'specialist' if the model's max benchmark score minus min benchmark score > 25, otherwise 'generalist', (5) Implement `rank(weights)` returning a list of (model_name, score) tuples sorted by weighted score descending."
+      },
+      "starter_code": "class BenchmarkProfiler:\n    def __init__(self, benchmarks):\n        self.benchmarks = benchmarks\n        self.models = {}\n\n    def add_model(self, name, scores):\n        # Store the scores dict for this model\n        pass\n\n    def weighted_score(self, model_name, weights):\n        # Compute weighted score normalized by sum of weights\n        # Use 0 for missing benchmarks, round to 1 decimal\n        pass\n\n    def classify(self, model_name):\n        # Return 'specialist' if spread > 25, else 'generalist'\n        pass\n\n    def rank(self, weights):\n        # Return [(name, score), ...] sorted by weighted score desc\n        pass\n\n# Test it:\nprofiler = BenchmarkProfiler([\"ifeval\", \"bbh\", \"math\", \"gpqa\"])\nprofiler.add_model(\"ModelA\", {\"ifeval\": 72.0, \"bbh\": 58.0, \"math\": 45.0, \"gpqa\": 31.0})\nprofiler.add_model(\"ModelB\", {\"ifeval\": 50.0, \"bbh\": 48.0, \"math\": 46.0, \"gpqa\": 44.0})\n\n# Weighted scoring\nassistant_weights = {\"ifeval\": 0.4, \"bbh\": 0.3, \"math\": 0.2, \"gpqa\": 0.1}\nprint(profiler.weighted_score(\"ModelA\", assistant_weights))\nprint(profiler.weighted_score(\"ModelB\", assistant_weights))\n\n# Classification\nprint(profiler.classify(\"ModelA\"))\nprint(profiler.classify(\"ModelB\"))\n\n# Ranking\nranked = profiler.rank(assistant_weights)\nprint(ranked[0][0])\nprint(ranked[1][0])",
+      "expected_output": "59.4\n48.4\nspecialist\ngeneralist\nModelA\nModelB",
+      "hints": {
+        "en": [
+          "In weighted_score, iterate weights.items(): total += scores.get(benchmark, 0) * weight. Then divide by sum(weights.values()) and round to 1 decimal.",
+          "In classify, get all benchmark scores for the model, compute max - min. If the spread > 25, return 'specialist'; otherwise 'generalist'.",
+          "In rank, call self.weighted_score(name, weights) for each model and sort the resulting (name, score) tuples by score descending."
+        ]
+      },
+      "test_code": "p = BenchmarkProfiler([\"a\", \"b\", \"c\"])\np.add_model(\"X\", {\"a\": 80.0, \"b\": 50.0, \"c\": 40.0})\np.add_model(\"Y\", {\"a\": 55.0, \"b\": 54.0, \"c\": 53.0})\np.add_model(\"Z\", {\"a\": 90.0, \"b\": 30.0, \"c\": 20.0})\nassert p.weighted_score(\"X\", {\"a\": 1.0}) == 80.0\nassert p.weighted_score(\"X\", {\"a\": 0.5, \"b\": 0.5}) == 65.0\nassert p.weighted_score(\"Y\", {\"a\": 1.0, \"b\": 1.0, \"c\": 1.0}) == 54.0\nassert p.classify(\"X\") == 'specialist'\nassert p.classify(\"Y\") == 'generalist'\nassert p.classify(\"Z\") == 'specialist'\nr = p.rank({\"a\": 1.0})\nassert r[0][0] == \"Z\"\nassert r[1][0] == \"X\"\nassert r[2][0] == \"Y\"\nr2 = p.rank({\"b\": 1.0, \"c\": 1.0})\nassert r2[0][0] == \"Y\"\nassert p.weighted_score(\"X\", {\"d\": 1.0}) == 0.0"
+    },
+    {
+      "instruction": {
+        "en": "Build a `LeaderboardFilter` class for shortlisting Open LLM Leaderboard models. It should: (1) Store models via `add_model(name, params_b, avg, **benchmarks)`, (2) Implement `filter(min_avg=0, max_params_b=None, required_benchmarks=None)` â€” return model names where avg >= min_avg, params_b <= max_params_b (skip check if None), and all required_benchmarks (list of str) have scores > 0 (skip check if None), sorted alphabetically, (3) Implement `head_to_head(model_a, model_b)` â€” return a dict mapping each stored benchmark name to the name of the model that scores higher on it (or 'tie' if equal)."
+      },
+      "starter_code": "class LeaderboardFilter:\n    def __init__(self):\n        self.models = {}\n\n    def add_model(self, name, params_b, avg, **benchmarks):\n        # Store model data\n        pass\n\n    def filter(self, min_avg=0, max_params_b=None, required_benchmarks=None):\n        # Return sorted list of model names passing all filters\n        pass\n\n    def head_to_head(self, model_a, model_b):\n        # Compare two models on every stored benchmark\n        # Return {benchmark: winner_name_or_'tie'}\n        pass\n\n# Test it:\nlf = LeaderboardFilter()\nlf.add_model(\"Alpha\", 7, 55.0, ifeval=70.0, bbh=58.0, math=40.0)\nlf.add_model(\"Beta\", 3, 42.0, ifeval=55.0, bbh=45.0)\nlf.add_model(\"Gamma\", 70, 72.0, ifeval=85.0, bbh=78.0, math=68.0)\n\n# Filter: avg >= 50, max 10B params\nresult = lf.filter(min_avg=50, max_params_b=10)\nprint(result)\n\n# Filter: must have math benchmark\nwith_math = lf.filter(required_benchmarks=[\"math\"])\nprint(with_math)\n\n# Head to head\nh2h = lf.head_to_head(\"Alpha\", \"Gamma\")\nprint(h2h[\"ifeval\"])\nprint(h2h[\"bbh\"])",
+      "expected_output": "['Alpha']\n['Alpha', 'Gamma']\nGamma\nGamma",
+      "hints": {
+        "en": [
+          "In add_model, store a dict with params_b, avg, and unpack **benchmarks. The benchmarks dict contains only the benchmark keys the caller passes.",
+          "In filter, check three conditions per model: avg >= min_avg, params_b <= max_params_b (skip if None), and all required_benchmarks exist with score > 0 in the model's data.",
+          "In head_to_head, collect all benchmark keys from BOTH models (union of keys excluding params_b/avg). For each, compare scores â€” if a model lacks the key, treat it as 0."
+        ]
+      },
+      "test_code": "f = LeaderboardFilter()\nf.add_model(\"M1\", 7, 60.0, x=80.0, y=40.0)\nf.add_model(\"M2\", 3, 45.0, x=30.0, y=90.0)\nf.add_model(\"M3\", 70, 80.0, x=85.0, y=85.0)\nassert f.filter(min_avg=50) == [\"M1\", \"M3\"]\nassert f.filter(max_params_b=10) == [\"M1\", \"M2\"]\nassert f.filter(min_avg=50, max_params_b=10) == [\"M1\"]\nassert f.filter() == [\"M1\", \"M2\", \"M3\"]\nassert f.filter(required_benchmarks=[\"y\"]) == [\"M1\", \"M2\", \"M3\"]\nh = f.head_to_head(\"M1\", \"M2\")\nassert h[\"x\"] == \"M1\"\nassert h[\"y\"] == \"M2\"\nh2 = f.head_to_head(\"M3\", \"M3\")\nassert h2[\"x\"] == \"tie\"\nassert h2[\"y\"] == \"tie\""
+    }
+  ],
+  "tags": {
+    "concepts_taught": [
+      "LLM benchmark interpretation",
+      "IFEval instruction following",
+      "BBH multi-step reasoning",
+      "MMLU-PRO broad knowledge",
+      "GPQA science evaluation",
+      "MuSR soft reasoning",
+      "weighted benchmark scoring",
+      "specialist vs generalist model profiles",
+      "benchmark red flag detection",
+      "leaderboard data querying"
+    ],
+    "concepts_required": [
+      "python basics",
+      "dictionaries",
+      "lists",
+      "functions",
+      "sorting"
+    ],
+    "difficulty": "beginner",
+    "engagement_type": "tutorial",
+    "estimated_minutes": 25,
+    "category": "ai_engineering",
+    "path_memberships": [
+      "ai_engineering"
+    ]
+  },
+  "generated": true
+}


### PR DESCRIPTION
## Auto-generated Lesson

**Topic:** Understanding LLM Benchmarks: Decode the Open LLM Leaderboard
**Track:** ai_engineering
**Source:** huggingface - [open-llm-leaderboard/open_llm_leaderboard](https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard)
**PyMasters Score:** 7/10

### Description
Learn what each Open LLM Leaderboard benchmark actually measures, how to query leaderboard results programmatically, and how to build a scoring profile that matches your Homie assistant's real-world needs.

### What's included
- Theory/explanation content (story_variants)
- Code examples (animation_sequence with CodeStepper)
- Practice challenges with tests

---
*Auto-generated by PyMasters AI Intelligence Pipeline*